### PR TITLE
feat: add IGW

### DIFF
--- a/bloom-instance/vpc.tf
+++ b/bloom-instance/vpc.tf
@@ -4,3 +4,11 @@ resource "aws_vpc" "vpc" {
   cidr_block = var.vpc_cidr
   tags       = local.default_tags_with_name
 }
+
+# The Internet Gateway (IGW) is what enables bidirectional communication
+# in our public subnet.  It's what makes the public subnet "public"
+resource "aws_internet_gateway" "igw" {
+  # Note that the IGW references the VPC we created above
+  vpc_id = aws_vpc.vpc.id
+  tags   = local.default_tags_with_name
+}


### PR DESCRIPTION
This CL, with #20, resolves #7

test plan:
`terraform plan` also adds a igw and the vpc remains the same (did not run `terraform apply` after #20, so it makes sense that it is still there as well)
![image](https://user-images.githubusercontent.com/10789523/220469889-057b48f5-7fe1-427b-8b96-9cd1e6214398.png)
