### PR TITLE
feat: add lint and formatting commit hooks

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,24 @@
+name: Check terraform file formatting
+
+on:
+  # Trigger the workflow on pull request,
+  # but only for the main branch
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_format:
+    defaults:
+      run:
+        working-directory: ./bloom-instance
+    runs-on: ubuntu-latest
+    name: Check terraform file are formatted correctly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: terraform fmt
+        uses: dflook/terraform-fmt-check@v1
+        with:
+          path: bloom-instance

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on:
+  # Trigger the workflow on pull request,
+  # but only for the dev branch
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tflint:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout source code
+
+      - uses: actions/cache@v3
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - uses: terraform-linters/setup-tflint@v3
+        name: Setup TFLint
+        with:
+          tflint_version: v0.44.1
+
+      - name: Show version
+        run: tflint --version
+
+      - name: Init TFLint
+        run: tflint --init
+
+      - name: Run TFLint
+        run: tflint -f compact

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   # Trigger the workflow on pull request,
-  # but only for the dev branch
+  # but only for the main branch
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,11 @@ on:
       - main
 
 jobs:
-  tflint:
+  tflint-bloom-instance:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./bloom-instance
 
     strategy:
       matrix:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1,0 +1,37 @@
+# TODO: Add secrets file and then re-enable. See
+# https://github.com/lisunshiny/doorway-infra/pull/3#issuecomment-1441076790
+# for screenshot of what happens when this workflow runs.
+
+# name: Create terraform plan
+
+# on:
+#   # Trigger the workflow on pull request,
+#   # but only for the main branch
+#   pull_request:
+#     branches:
+#       - main
+
+# permissions:
+#   contents: read
+#   pull-requests: write
+
+# jobs:
+#   plan-bloom-instance:
+#     defaults:
+#       run:
+#         working-directory: ./bloom-instance
+
+#     runs-on: ubuntu-latest
+#     name: Create a plan for an example terraform configuration
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v3
+
+#       - name: terraform plan
+#         uses: dflook/terraform-plan@v1
+#         with:
+#           path: bloom-instance
+#           var_file: |
+#             tfvars.template
+#           add_github_comment: false
+#           workspace: ci

--- a/bloom-instance/.tflint.hcl
+++ b/bloom-instance/.tflint.hcl
@@ -1,0 +1,10 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.21.2"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.3"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -60,7 +60,7 @@ variable "sdlc_stage" {
 }
 
 variable "subnet_map" {
-  type        = object({
+  type = object({
     public = list(object({
       az   = string
       cidr = string


### PR DESCRIPTION
Addresses #30

This CL adds 3 new GitHub workflows (but only 2 are enabled)
* A hook to run linting (https://github.com/terraform-linters/tflint) which checks for unused variables, etc.
* A hook to run terraform fmt (https://github.com/dflook/terraform-github-actions/tree/main/terraform-fmt-check) and fail if files are not properly formatted
* A hook that I commented out to show the output of `terraform plan`. This seems super useful but is not related to formatting and is probably more CI/CD related vs. just enforcing formatting. Happy to just delete the file if we don't think we'll use this at all. 

Note I will squash merge given that my commit messages are... creative.