### PR TITLE
metrotranscom/doorway-infra/issues/13

### DIFF
--- a/bloom-instance/ecr.tf
+++ b/bloom-instance/ecr.tf
@@ -1,0 +1,17 @@
+resource "aws_ecr_repository" "prod_repo" {
+  name                 = "prod"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_repository" "dev_repo" {
+  name                 = "dev"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}


### PR DESCRIPTION
Some options here are

* move this to a folder above, a peer of `bloom-instance`, into a `ci` folder- the idea being it's not tied to the application architecture. Additionally, this infra won't have multiple versions for different workspaces. 
* we can remove scan on upload for prod and ensure we're doing this at another stage. This would could save some money, by avoiding scanning on all uploads. 