### PR TITLE
add partner site

### DIFF
--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -66,6 +66,7 @@ module "public_alb" {
   }
 }
 
+# There may be multiple public sites
 module "public_sites" {
   for_each = { for idx, srv in var.public_sites : idx => srv }
   source   = "./services/public-site"
@@ -86,5 +87,28 @@ module "public_sites" {
   additional_tags = {
     ServiceType = "public-site"
     ServiceName = each.value.name
+  }
+}
+
+# So far, there only seems to be a need for a single partner site
+module "partner_site" {
+  source = "./services/partner-site"
+
+  name_prefix        = local.default_name
+  service_definition = var.partner_site
+
+  alb_listener_arn = module.public_alb.listeners.public.arn
+  alb_sg_id        = module.public_alb.security_group.id
+  subnet_ids       = [for subnet in module.network.subnets.app : subnet.id]
+
+  public_upload_bucket = aws_s3_bucket.user_upload_bucket.bucket
+  secure_upload_bucket = aws_s3_bucket.user_upload_bucket.bucket
+
+  # Just a placeholder for now
+  backend_api_base = "http://localhost:3100"
+
+  additional_tags = {
+    ServiceType = "partner-site"
+    ServiceName = var.partner_site.name
   }
 }

--- a/bloom-instance/services/partner-site/iam.tf
+++ b/bloom-instance/services/partner-site/iam.tf
@@ -1,0 +1,47 @@
+
+resource "aws_iam_role" "service" {
+  name = "${local.resource_namespace}-ecs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Permit ECS to assume this role
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "service_s3_access" {
+  name = "${local.resource_namespace}-s3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "ReadWriteObjects"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectAttributes",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionAttributes",
+          "s3:GetObjectVersionTagging",
+          "s3:PutObject",
+        ]
+        Effect   = "Allow"
+        Resource = local.s3_access_policy_object_resource,
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "service_s3_access" {
+  role       = aws_iam_role.service.name
+  policy_arn = aws_iam_policy.service_s3_access.arn
+}

--- a/bloom-instance/services/partner-site/inputs.tf
+++ b/bloom-instance/services/partner-site/inputs.tf
@@ -1,0 +1,52 @@
+
+variable "name_prefix" {
+  type        = string
+  description = "A prefix to be used when creating resources to provide a distinct, yet recognizable name"
+
+  validation {
+    condition     = can(regex("^[[:alnum:]\\-]+$", var.name_prefix))
+    error_message = "name_prefix can only contain letters, numbers, and hyphens"
+  }
+}
+
+variable "service_definition" {
+  # See services/base-service/inputs.tf for object structure
+  type        = any
+  description = "A public portal service definition object"
+}
+
+variable "alb_listener_arn" {
+  type        = string
+  description = "The ARN of the ALB Listener to add this service to"
+}
+
+variable "alb_sg_id" {
+  type        = string
+  description = "The ID of the ALB Security Group to permit access from"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "The ID(s) of the subnet(s) to run this service in"
+}
+
+variable "backend_api_base" {
+  type        = string
+  description = "The base URL for the backend API"
+}
+
+variable "public_upload_bucket" {
+  type        = string
+  description = "The name of the bucket to use for publicly available file uploads"
+}
+
+variable "secure_upload_bucket" {
+  type        = string
+  description = "The name of the bucket to use for secure file uploads"
+}
+
+variable "additional_tags" {
+  type        = map(string)
+  default     = null
+  description = "Additional tags to apply to public site resources"
+}

--- a/bloom-instance/services/partner-site/locals.tf
+++ b/bloom-instance/services/partner-site/locals.tf
@@ -1,0 +1,45 @@
+
+locals {
+  # The port for this service to listen on
+  port = var.service_definition.port != null ? var.service_definition.port : 3001
+
+  # Add service-specific env vars
+  env_vars = merge(
+    var.service_definition.env_vars,
+    tomap({
+      # Core Bloom vars
+      NEXTJS_PORT      = local.port,
+      BACKEND_API_BASE = var.backend_api_base
+
+      # AWS-specific vars
+      PUBLIC_BUCKET_NAME = var.public_upload_bucket
+      SECURE_BUCKET_NAME = var.secure_upload_bucket
+      UPLOAD_PREFIX      = local.bucket_prefix
+    })
+  )
+
+  service_definition = merge(
+    var.service_definition,
+    {
+      env_vars = local.env_vars
+    }
+  )
+
+  # A namespace for resources created in this module
+  resource_namespace = "${var.name_prefix}-service-${var.service_definition.name}"
+
+  # The prefix to use when saving files to upload buckets
+  bucket_prefix = "${var.name_prefix}/${var.service_definition.name}"
+
+  # The ARN pattern scoping access to the public upload bucket
+  public_bucket_arn = "arn:aws:s3:::${var.public_upload_bucket}"
+
+  # The ARN pattern scoping access to the secure upload bucket
+  secure_bucket_arn = "arn:aws:s3:::${var.secure_upload_bucket}"
+
+  # The value to use in IAM policies restricting access to upload objects
+  s3_access_policy_object_resource = [
+    "${local.public_bucket_arn}/${local.bucket_prefix}/*",
+    "${local.secure_bucket_arn}/${local.bucket_prefix}/*",
+  ]
+}

--- a/bloom-instance/services/partner-site/outputs.tf
+++ b/bloom-instance/services/partner-site/outputs.tf
@@ -1,0 +1,8 @@
+
+output "target_group" {
+  value = module.service.target_group
+}
+
+output "security_group" {
+  value = module.service.security_group
+}

--- a/bloom-instance/services/partner-site/service.tf
+++ b/bloom-instance/services/partner-site/service.tf
@@ -1,0 +1,15 @@
+
+module "service" {
+  source = "../base-service"
+
+  name_prefix = var.name_prefix
+  #service_name       = var.service_definition.name
+  service_definition = local.service_definition
+
+  alb_listener_arn = var.alb_listener_arn
+  alb_sg_id        = var.alb_sg_id
+  subnet_ids       = var.subnet_ids
+  task_role_arn    = aws_iam_role.service.arn
+
+  additional_tags = var.additional_tags
+}

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -60,3 +60,20 @@ public_sites = [
     }
   }
 ]
+
+partner_site = {
+  name = "partner"
+  cpu = 256
+  ram = 512
+  image = "nginx:latest"
+  port = 80
+  domains = [ "partner.doorway.test" ]
+
+  health_check = { }
+
+  env_vars = {
+    LISTINGS_QUERY = "/listings"
+    SHOW_DUPLICATES = "false"
+    SHOW_LM_LINKS = "true"
+  }
+}

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -94,3 +94,9 @@ variable "public_sites" {
   type        = any
   description = "A list of public portal service definitions"
 }
+
+variable "partner_site" {
+  # See services/base-service/inputs.tf for object structure
+  type        = any
+  description = "A service definition for the partner site"
+}


### PR DESCRIPTION
The partner site module is virtually identical to the public site, although it's expected that these will deviate somewhat more over time.

Resolves #46 

[plan.txt](https://github.com/metrotranscom/doorway-infra/files/10961588/plan.txt)
