### PR TITLE
add ecr policy

### DIFF
--- a/setup/ecr/inputs.tf
+++ b/setup/ecr/inputs.tf
@@ -1,0 +1,36 @@
+
+variable "name_prefix" {
+  type        = string
+  description = "The prefix to prepend to resource names"
+
+  validation {
+    condition     = can(regex("^[[:alnum:]\\-]+$", var.name_prefix))
+    error_message = "name_prefix can only contain letters, numbers, and hyphens"
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "The name to give to give to this ALB and its related resources"
+
+  validation {
+    condition     = can(regex("^[[:alnum:]\\-]+$", var.name))
+    error_message = "name can only contain letters, numbers, and hyphens"
+  }
+}
+
+variable "scan_images" {
+  type        = bool
+  default     = false
+  description = "Whether to scan images pushed to the ECR repo"
+}
+
+variable "source_account" {
+  type        = string
+  description = "The ID of the account where images will be pushed and/or pulled from"
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.source_account))
+    error_message = "source_account must be a valid AWS Account ID (12 numbers, no hyphens)"
+  }
+}

--- a/setup/ecr/outputs.tf
+++ b/setup/ecr/outputs.tf
@@ -1,0 +1,8 @@
+
+output "arn" {
+  value = aws_ecr_repository.repo.arn
+}
+
+output "url" {
+  value = aws_ecr_repository.repo.repository_url
+}

--- a/setup/ecr/policy.tf
+++ b/setup/ecr/policy.tf
@@ -1,0 +1,80 @@
+
+resource "aws_ecr_repository_policy" "repo" {
+  repository = aws_ecr_repository.repo.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudBuildPushPull"
+        Effect = "Allow"
+
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+        ]
+
+        # TODO: restrict CloudBuild access more?
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = var.source_account
+          }
+        }
+      },
+
+      {
+        Sid    = "AllowECSPull"
+        Effect = "Allow"
+
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:ListImages",
+        ]
+
+        # TODO: restrict ECR access more?
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = var.source_account
+          }
+        }
+      },
+
+      {
+        Sid    = "AllowUserPushPull"
+        Effect = "Allow"
+
+        # This permits all users in the specified account to take the following actions
+        # Any users in that account will still need to have IAM permissions granted
+        Principal = {
+          AWS = "${var.source_account}"
+        }
+
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchDeleteImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+        ]
+      }
+    ]
+  })
+}

--- a/setup/ecr/repo.tf
+++ b/setup/ecr/repo.tf
@@ -1,6 +1,6 @@
 
 resource "aws_ecr_repository" "repo" {
-  name = local.name_prefix
+  name = "${var.name_prefix}/${var.name}"
 
   encryption_configuration {
     encryption_type = "AES256"

--- a/setup/main.tf
+++ b/setup/main.tf
@@ -25,10 +25,26 @@ provider "aws" {
   }
 }
 
+# Needed to resolve current AWS Account ID for policy documents
+data "aws_caller_identity" "current" {}
+
 locals {
   # environment is set to workspace name if not explicitly set via var
   environment = var.environment != "default" ? var.environment : terraform.workspace
 
   # name_prefix is used to namespace resources based on a combination of project_id and scope
   name_prefix = "${var.project_id}-${local.environment}"
+
+  #The ID for the Account that our resources are being deployed into
+  current_account_id = data.aws_caller_identity.current.account_id
+}
+
+module "repos" {
+  for_each = { for name, repo in var.repos : name => repo }
+  source   = "./ecr"
+
+  name_prefix    = local.name_prefix
+  name           = each.key
+  scan_images    = each.value.scan_images
+  source_account = each.value.source_account != null ? each.value.source_account : local.current_account_id
 }

--- a/setup/outputs.tf
+++ b/setup/outputs.tf
@@ -1,8 +1,4 @@
 
-output "repo_arn" {
-    value = aws_ecr_repository.repo.arn
-}
-
-output "repo_url" {
-    value = aws_ecr_repository.repo.repository_url
+output "repos" {
+  value = module.repos
 }

--- a/setup/tfvars.template
+++ b/setup/tfvars.template
@@ -3,4 +3,20 @@ project_id = "doorway"
 aws_region = "us-west-1"
 owner = "infra_team+setup@your-org.dev"
 #environment = "<only_override_if_needed>"
-scan_images = false
+
+repos = {
+    public = {
+        scan_images = false
+        source_account = null
+    }
+
+    partners = {
+        scan_images = false
+        source_account = null
+    }
+
+    backend = {
+        scan_images = false
+        source_account = null
+    }
+}

--- a/setup/vars.tf
+++ b/setup/vars.tf
@@ -54,8 +54,11 @@ variable "environment" {
   }
 }
 
-variable "scan_images" {
-  type        = bool
-  default     = false
-  description = "Whether to scan images pushed to the ECR repo"
+variable "repos" {
+  type = map(object({
+    scan_images    = bool
+    source_account = optional(string)
+  }))
+
+  description = "A map of objects containing information for creating ECR repos"
 }


### PR DESCRIPTION
The ECR repo needs a policy to tell it what sort of access is allowed.  I added statements allowing CodeBuild, ECS, and users in the account where resources will be deployed.  I also moved the ECR config into a module and modified the tfvars template to create a separate repo for each of the 3 services to minimize the chance of clobbering one image with another.

Fixes #63 

[plan.txt](https://github.com/metrotranscom/doorway-infra/files/10994922/plan.txt)
