### PR TITLE
Add cert module

### DIFF
--- a/bloom-instance/cert/inputs.tf
+++ b/bloom-instance/cert/inputs.tf
@@ -1,0 +1,10 @@
+
+variable "cert" {
+  type = object({
+    domain    = string
+    zone      = string
+    alt_names = optional(list(string))
+  })
+
+  description = "Information about the TLS certificate to create"
+}

--- a/bloom-instance/cert/inputs.tf
+++ b/bloom-instance/cert/inputs.tf
@@ -1,8 +1,13 @@
 
+variable "zones" {
+  type        = map(string)
+  description = "A map of zone names to IDs"
+}
+
 variable "cert" {
   type = object({
-    domain    = string
-    zone      = string
+    domain = string
+    #zone      = string
     alt_names = optional(list(string))
   })
 

--- a/bloom-instance/cert/inputs.tf
+++ b/bloom-instance/cert/inputs.tf
@@ -6,9 +6,9 @@ variable "zones" {
 
 variable "cert" {
   type = object({
-    domain = string
-    #zone      = string
-    alt_names = optional(list(string))
+    domain        = string
+    auto_validate = optional(bool, true)
+    alt_names     = optional(list(string))
   })
 
   description = "Information about the TLS certificate to create"

--- a/bloom-instance/cert/main.tf
+++ b/bloom-instance/cert/main.tf
@@ -1,26 +1,98 @@
 
+locals {
+  # DNS records required for cert validation
+  validation_records = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      values = [dvo.resource_record_value]
+      type   = dvo.resource_record_type
+      ttl    = 60
+    }
+  }
+
+  # Zones that we know about and can resolve to a specific ID
+  matched_zones = { for domain, zone in module.zones : domain => zone.id if zone.id != null }
+
+  # Domain names that cannot be resolved to a known zone
+  unmatched_zones = [for domain, zone in module.zones : domain if zone.id == null]
+
+  # The records we're going to create automatically
+  matched_records = { for domain, zone_id in local.matched_zones : domain => merge(
+    {
+      zone_id = zone_id
+    },
+    local.validation_records[domain]
+    )
+  }
+
+  # The records that do not match a known zone and must be created manually elsewhere
+  unmatched_records = { for domain in local.unmatched_zones : domain => local.validation_records[domain] }
+}
+
+
 resource "aws_acm_certificate" "cert" {
   domain_name               = var.cert.domain
   validation_method         = "DNS"
   subject_alternative_names = var.cert.alt_names
 }
 
+module "zones" {
+  source = "../dns/zone-resolver"
+
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => dvo.resource_record_name
+  }
+
+  zone_map = var.zones
+  dns_name = each.value
+}
+
 resource "aws_route53_record" "cert" {
+  /*
+  for_each = {
+    for dvo in local.matched_records : dvo.domain_name => dvo
+  }
+  */
+
   for_each = {
     for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
+      name    = dvo.resource_record_name
+      values  = [dvo.resource_record_value]
+      type    = dvo.resource_record_type
+      ttl     = 60
+      zone_id = module.zones[dvo.domain_name].id
+    } #if module.zones[dvo.domain_name] != null && module.zones[dvo.domain_name].found
   }
 
   allow_overwrite = true
   name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
+  records         = each.value.values
+  ttl             = each.value.ttl
   type            = each.value.type
-  zone_id         = var.cert.zone
+  zone_id         = each.value.zone_id
+
+  depends_on = [
+    aws_acm_certificate.cert,
+    module.zones
+  ]
 }
+
+/*
+module "verification_records" {
+  source = "../dns/record"
+
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      values = [dvo.resource_record_value]
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zones  = var.zones
+  record = each.value
+}
+*/
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn         = aws_acm_certificate.cert.arn

--- a/bloom-instance/cert/main.tf
+++ b/bloom-instance/cert/main.tf
@@ -1,0 +1,28 @@
+
+resource "aws_acm_certificate" "cert" {
+  domain_name               = var.cert.domain
+  validation_method         = "DNS"
+  subject_alternative_names = var.cert.alt_names
+}
+
+resource "aws_route53_record" "cert" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.cert.zone
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert : record.fqdn]
+}

--- a/bloom-instance/cert/outputs.tf
+++ b/bloom-instance/cert/outputs.tf
@@ -1,0 +1,4 @@
+
+output "arn" {
+  value = aws_acm_certificate.cert.arn
+}

--- a/bloom-instance/cert/outputs.tf
+++ b/bloom-instance/cert/outputs.tf
@@ -2,3 +2,7 @@
 output "arn" {
   value = aws_acm_certificate.cert.arn
 }
+
+output "unmatched_validation_records" {
+  value = local.unmatched_records
+}

--- a/bloom-instance/certs.tf
+++ b/bloom-instance/certs.tf
@@ -1,0 +1,7 @@
+
+module "certs" {
+  source   = "./cert"
+  for_each = { for key, cert in var.certs : key => cert }
+
+  cert = each.value
+}

--- a/bloom-instance/certs.tf
+++ b/bloom-instance/certs.tf
@@ -1,7 +1,7 @@
 
 module "certs" {
   source   = "./cert"
-  for_each = { for cert in var.certs : cert.domain => cert }
+  for_each = { for name, cert in var.certs : name => cert }
 
   zones = module.dns.zone_map
   cert  = each.value

--- a/bloom-instance/certs.tf
+++ b/bloom-instance/certs.tf
@@ -1,7 +1,7 @@
 
 module "certs" {
   source   = "./cert"
-  for_each = { for key, cert in var.certs : key => cert }
+  for_each = { for cert in var.certs : cert.domain => cert }
 
   zones = module.dns.zone_map
   cert  = each.value

--- a/bloom-instance/certs.tf
+++ b/bloom-instance/certs.tf
@@ -3,5 +3,6 @@ module "certs" {
   source   = "./cert"
   for_each = { for key, cert in var.certs : key => cert }
 
-  cert = each.value
+  zones = module.dns.zone_map
+  cert  = each.value
 }

--- a/bloom-instance/dns/record/outputs.tf
+++ b/bloom-instance/dns/record/outputs.tf
@@ -1,4 +1,4 @@
 
 output "fqdn" {
-  value = aws_route53_record.record.fqdn
+  value = local.zone_id != null ? aws_route53_record.record[0].fqdn : null
 }

--- a/bloom-instance/dns/record/outputs.tf
+++ b/bloom-instance/dns/record/outputs.tf
@@ -1,0 +1,4 @@
+
+output "fqdn" {
+  value = aws_route53_record.record.fqdn
+}

--- a/bloom-instance/dns/zone-resolver/inputs.tf
+++ b/bloom-instance/dns/zone-resolver/inputs.tf
@@ -5,6 +5,13 @@ variable "zone_map" {
 }
 
 variable "dns_name" {
-  type        = string
+  type = string
+
+  validation {
+    # This is just very basic validation to catch any obvious errors
+    condition     = can(regex("^([0-9a-z\\-]+\\.)+[0-9a-z\\-]+$", var.dns_name))
+    error_message = "DNS name must be a valid domain"
+  }
+
   description = "The DNS name to find the matching zones for"
 }

--- a/bloom-instance/dns/zone-resolver/inputs.tf
+++ b/bloom-instance/dns/zone-resolver/inputs.tf
@@ -1,0 +1,10 @@
+
+variable "zone_map" {
+  type        = map(string)
+  description = "A map of zone names to IDs"
+}
+
+variable "dns_name" {
+  type        = string
+  description = "The DNS name to find the matching zones for"
+}

--- a/bloom-instance/dns/zone-resolver/main.tf
+++ b/bloom-instance/dns/zone-resolver/main.tf
@@ -33,12 +33,8 @@ locals {
   reverse_lengths = reverse(local.sort_lengths)
 
   # The longest zone/domain name
-  longest = local.by_length[local.reverse_lengths[0]]
+  longest = length(local.reverse_lengths) > 0 ? local.by_length[local.reverse_lengths[0]] : null
 
-  match = length(local.filter) > 0 ? local.matches[local.longest] : null
-
-  # Return the first (hopefully only) match
-  # this should more accurately be the match with the longest zone name 
-  # (higher specificity), but it's unlikely that would be a valid use case.
-  #match = length(local.matches) > 0 ? local.matches[0] : null
+  # The match, if any, is the zone with the longest matching suffix (ie highest specificity)
+  match = local.longest != null ? local.matches[local.longest] : null
 }

--- a/bloom-instance/dns/zone-resolver/main.tf
+++ b/bloom-instance/dns/zone-resolver/main.tf
@@ -1,0 +1,22 @@
+
+# This module doesn't create any resources.  All it does is provide a simple, 
+# repeatable means for determining which zone ID to use for applying DNS records
+
+locals {
+  # Find any zones that are a valid suffix for the record DNS name
+  # The match logic could probably be improved
+  filter = { for zone_name, zone_id in var.zone_map : zone_name => zone_id if endswith(var.dns_name, zone_name) }
+
+  # Put the matches into a list of tuples
+  # This could be consolidated with the filter step above, but it's kept 
+  # separate in case the map above ends up being useful in other ways
+  matches = [for name, id in local.filter : {
+    name = name
+    id   = id
+  }]
+
+  # Return the first (hopefully only) match
+  # this should more accurately be the match with the longest zone name 
+  # (higher specificity), but it's unlikely that would be a valid use case.
+  match = local.matches[0]
+}

--- a/bloom-instance/dns/zone-resolver/outputs.tf
+++ b/bloom-instance/dns/zone-resolver/outputs.tf
@@ -1,0 +1,12 @@
+
+output "found" {
+  value = local.match != null
+}
+
+output "name" {
+  value = local.match != null ? local.match.name : null
+}
+
+output "id" {
+  value = local.match != null ? local.match.id : null
+}

--- a/bloom-instance/outputs.tf
+++ b/bloom-instance/outputs.tf
@@ -1,0 +1,4 @@
+
+output "cert_validation_records_not_created" {
+  value = { for key, cert in module.certs : key => cert.unmatched_validation_records }
+}

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -53,6 +53,29 @@ dns = {
   }
 }
 
+certs = [
+  {
+    domain = "doorway.test"
+    alt_names = [
+      # Wildcards are supported
+      "*.doorway.test"
+    ]
+  },
+  {
+    # Certs can be created for unmanaged/external domains
+    domain = "doorway.external"
+
+    # Just set auto_validate to false
+    auto_validate = false
+
+    alt_names = [
+      "public.doorway.external",
+      "partners.doorway.external",
+      "api.doorway.external"
+    ]
+  }
+]
+
 public_sites = [
   {
     name = "public"

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -53,19 +53,19 @@ dns = {
   }
 }
 
-certs = [
-  {
+certs = {
+  "doorway" = {
     domain = "doorway.test"
     alt_names = [
       # Wildcards are supported
       "*.doorway.test"
     ]
   },
-  {
+  "doorway-external" = {
     # Certs can be created for unmanaged/external domains
     domain = "doorway.external"
 
-    # Just set auto_validate to false
+    # Just set auto_validate to false to prevent record creation
     auto_validate = false
 
     alt_names = [
@@ -74,7 +74,7 @@ certs = [
       "api.doorway.external"
     ]
   }
-]
+}
 
 public_sites = [
   {

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -118,7 +118,11 @@ variable "partner_site" {
 }
 
 variable "certs" {
-  # See cert/inputs.tf for object structure
-  type        = map(any)
+  # Keep a well-defined type here to avoid input validation issues with "any"
+  type = list(object({
+    domain        = string
+    auto_validate = optional(bool)
+    alt_names     = optional(list(string))
+  }))
   description = "The certifcates to use"
 }

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -100,3 +100,9 @@ variable "partner_site" {
   type        = any
   description = "A service definition for the partner site"
 }
+
+variable "certs" {
+  # See cert/inputs.tf for object structure
+  type        = map(any)
+  description = "The certifcates to use"
+}

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -119,7 +119,7 @@ variable "partner_site" {
 
 variable "certs" {
   # Keep a well-defined type here to avoid input validation issues with "any"
-  type = list(object({
+  type = map(object({
     domain        = string
     auto_validate = optional(bool)
     alt_names     = optional(list(string))


### PR DESCRIPTION
This PR adds a cert module and a related var that instructs which certs to create.  It uses a re-added zone-resolver module to determine which DNS zone to use for automatically adding DNS validation records.  Certs are currently not being assigned to any resources, but the cert var uses a map so that other components (such as the alb module) can specify which certs to use via alias values since they won't know the ARN until apply-time.

Resolves #75 