### PR TITLE
79/add alb config

### DIFF
--- a/bloom-instance/alb.tf
+++ b/bloom-instance/alb.tf
@@ -1,0 +1,36 @@
+
+module "albs" {
+  source   = "./alb"
+  for_each = { for name, alb in var.albs : name => alb }
+
+  vpc_id     = module.network.vpc.id
+  log_bucket = aws_s3_bucket.logging_bucket.bucket
+  #subnet_ids = [for subnet in module.network.subnets[each.value.subnet_group] : subnet.id]
+  # Pass in available subnets so the ALB can pick which subnets to deploy into based on subnet group
+  # Also used by listener module to allow IPs from subnets in allowed_subnets
+  subnets = module.network.subnets
+
+  name_prefix    = local.default_name
+  name           = each.key
+  enable_logging = each.value.enable_logging
+  internal       = each.value.internal
+  listeners      = each.value.listeners
+  subnet_group   = each.value.subnet_group
+
+  /*
+  listeners = {
+    public = {
+      port        = 80
+      use_tls     = false
+      allowed_ips = ["0.0.0.0/0"]
+    }
+
+    # internal is here just to provide an easy path forward if we want an internal route to services
+    internal = {
+      port        = 8080
+      use_tls     = false
+      allowed_ips = [for subnet in module.network.subnets.app : subnet.cidr_block]
+    }
+  }
+  */
+}

--- a/bloom-instance/alb.tf
+++ b/bloom-instance/alb.tf
@@ -5,10 +5,14 @@ module "albs" {
 
   vpc_id     = module.network.vpc.id
   log_bucket = aws_s3_bucket.logging_bucket.bucket
-  #subnet_ids = [for subnet in module.network.subnets[each.value.subnet_group] : subnet.id]
+
   # Pass in available subnets so the ALB can pick which subnets to deploy into based on subnet group
   # Also used by listener module to allow IPs from subnets in allowed_subnets
   subnets = module.network.subnets
+
+  # Provide a map of managed certificates so the config can refer to them by name rather than ARN
+  # The ARN is then resolved by the listener module based on the tls config
+  cert_map = { for name, cert in module.certs : name => cert.arn }
 
   name_prefix    = local.default_name
   name           = each.key
@@ -16,21 +20,4 @@ module "albs" {
   internal       = each.value.internal
   listeners      = each.value.listeners
   subnet_group   = each.value.subnet_group
-
-  /*
-  listeners = {
-    public = {
-      port        = 80
-      use_tls     = false
-      allowed_ips = ["0.0.0.0/0"]
-    }
-
-    # internal is here just to provide an easy path forward if we want an internal route to services
-    internal = {
-      port        = 8080
-      use_tls     = false
-      allowed_ips = [for subnet in module.network.subnets.app : subnet.cidr_block]
-    }
-  }
-  */
 }

--- a/bloom-instance/alb/alb.tf
+++ b/bloom-instance/alb/alb.tf
@@ -6,7 +6,7 @@ resource "aws_lb" "alb" {
   security_groups    = [aws_security_group.alb.id]
 
   # Note that an ALB requires at least 2 subnets
-  subnets = var.subnet_ids
+  subnets = [for subnet in var.subnets[var.subnet_group] : subnet.id]
 
   enable_deletion_protection = false
 

--- a/bloom-instance/alb/inputs.tf
+++ b/bloom-instance/alb/inputs.tf
@@ -31,9 +31,11 @@ variable "subnet_ids" {
 
 variable "listeners" {
   type = map(object({
-    port        = number
-    use_tls     = bool
-    allowed_ips = list(string)
+    port             = number
+    use_tls          = bool
+    default_cert     = optional(string)
+    additional_certs = optional(list(string))
+    allowed_ips      = list(string)
   }))
   default     = null
   description = "The listeners to create"
@@ -43,6 +45,13 @@ variable "listeners" {
       for l in var.listeners : l.port > 0 && l.port <= 65535
     ])
     error_message = "Port numbers must be in valid range"
+  }
+
+  validation {
+    condition = !alltrue([
+      for l in var.listeners : l.use_tls && l.default_cert == null
+    ])
+    error_message = "default_cert is required if use_tls is true"
   }
 }
 
@@ -67,3 +76,10 @@ variable "additional_tags" {
   default     = null
   description = "Additional tags to apply to ALB resources"
 }
+
+/*
+variable "certs" {
+  type        = map(string)
+  description = "ARNs for TLS certificates to apply to secure listeners"
+}
+*/

--- a/bloom-instance/alb/inputs.tf
+++ b/bloom-instance/alb/inputs.tf
@@ -26,7 +26,8 @@ variable "vpc_id" {
 
 variable "subnets" {
   type = map(list(object({
-    id = string
+    id   = string
+    cidr = string
   })))
   description = "A map of the available subnets"
 }

--- a/bloom-instance/alb/inputs.tf
+++ b/bloom-instance/alb/inputs.tf
@@ -24,10 +24,24 @@ variable "vpc_id" {
   description = "The ID of the VPC to create ALB resources in"
 }
 
+variable "subnets" {
+  type = map(list(object({
+    id = string
+  })))
+  description = "A map of the available subnets"
+}
+
+variable "subnet_group" {
+  type        = string
+  description = "The identifier for the subnet group to place the ALB into"
+}
+
+/*
 variable "subnet_ids" {
   type        = list(string)
   description = "The IDs of the subnets to create the ALB in"
 }
+*/
 
 variable "listeners" {
   type = map(object({
@@ -35,7 +49,8 @@ variable "listeners" {
     use_tls          = bool
     default_cert     = optional(string)
     additional_certs = optional(list(string))
-    allowed_ips      = list(string)
+    allowed_ips      = optional(list(string), [])
+    allowed_subnets  = optional(list(string))
   }))
   default     = null
   description = "The listeners to create"
@@ -63,6 +78,7 @@ variable "internal" {
 
 variable "enable_logging" {
   type        = bool
+  default     = true
   description = "Whether to enable logging on this ALB"
 }
 

--- a/bloom-instance/alb/inputs.tf
+++ b/bloom-instance/alb/inputs.tf
@@ -40,7 +40,7 @@ variable "subnet_group" {
 variable "listeners" {
   type = map(object({
     port           = number
-    default_action = optional(string)
+    default_action = string
 
     allowed_ips     = optional(list(string))
     allowed_subnets = optional(list(string))

--- a/bloom-instance/alb/inputs.tf
+++ b/bloom-instance/alb/inputs.tf
@@ -73,9 +73,7 @@ variable "additional_tags" {
   description = "Additional tags to apply to ALB resources"
 }
 
-/*
-variable "certs" {
+variable "cert_map" {
   type        = map(string)
   description = "ARNs for TLS certificates to apply to secure listeners"
 }
-*/

--- a/bloom-instance/alb/inputs.tf
+++ b/bloom-instance/alb/inputs.tf
@@ -37,38 +37,17 @@ variable "subnet_group" {
   description = "The identifier for the subnet group to place the ALB into"
 }
 
-/*
-variable "subnet_ids" {
-  type        = list(string)
-  description = "The IDs of the subnets to create the ALB in"
-}
-*/
-
 variable "listeners" {
   type = map(object({
-    port             = number
-    use_tls          = bool
-    default_cert     = optional(string)
-    additional_certs = optional(list(string))
-    allowed_ips      = optional(list(string), [])
-    allowed_subnets  = optional(list(string))
+    port           = number
+    default_action = optional(string)
+
+    allowed_ips     = optional(list(string))
+    allowed_subnets = optional(list(string))
+
+    tls = optional(any)
   }))
-  default     = null
   description = "The listeners to create"
-
-  validation {
-    condition = alltrue([
-      for l in var.listeners : l.port > 0 && l.port <= 65535
-    ])
-    error_message = "Port numbers must be in valid range"
-  }
-
-  validation {
-    condition = !alltrue([
-      for l in var.listeners : l.use_tls && l.default_cert == null
-    ])
-    error_message = "default_cert is required if use_tls is true"
-  }
 }
 
 variable "internal" {

--- a/bloom-instance/alb/listener.tf
+++ b/bloom-instance/alb/listener.tf
@@ -4,19 +4,19 @@ module "listeners" {
 
   for_each = { for k, v in var.listeners : k => v }
 
-  subnets           = var.subnets
+  # Passthru
+  subnets  = var.subnets
+  cert_map = var.cert_map
+
+  # Module resources
   alb_arn           = aws_lb.alb.arn
   security_group_id = aws_security_group.alb.id
 
-  #settings = each.value
-
+  # From config
   port            = each.value.port
   tls             = each.value.tls
   allowed_ips     = each.value.allowed_ips
   allowed_subnets = each.value.allowed_subnets
-  #use_tls      = each.value.use_tls
-  #force_tls    = each.value.force_tls
-  #default_cert = each.value.default_cert
 
   additional_tags = var.additional_tags
 }

--- a/bloom-instance/alb/listener.tf
+++ b/bloom-instance/alb/listener.tf
@@ -1,4 +1,5 @@
 
+/*
 resource "aws_lb_listener" "alb_listeners" {
   for_each          = { for k, v in var.listeners : k => v }
   load_balancer_arn = aws_lb.alb.arn
@@ -16,4 +17,30 @@ resource "aws_lb_listener" "alb_listeners" {
   }
 
   tags = var.additional_tags
+}
+*/
+
+module "listeners" {
+  source = "./listener"
+
+  for_each = { for k, v in var.listeners : k => v }
+
+  subnets           = var.subnets
+  alb_arn           = aws_lb.alb.arn
+  security_group_id = aws_security_group.alb.id
+
+  settings = each.value
+
+  additional_tags = var.additional_tags
+
+  /*
+  port             = each.value.port
+  use_tls          = each.value.use_tls
+  force_tls        = each.value.force_tls
+  default_cert     = each.value.default_cert
+  additional_certs = optional(list(string))
+  allowed_ips      = list(string)
+  allowed_subnets  = list(string)
+  */
+
 }

--- a/bloom-instance/alb/listener.tf
+++ b/bloom-instance/alb/listener.tf
@@ -1,25 +1,4 @@
 
-/*
-resource "aws_lb_listener" "alb_listeners" {
-  for_each          = { for k, v in var.listeners : k => v }
-  load_balancer_arn = aws_lb.alb.arn
-  port              = each.value.port
-  protocol          = each.value.use_tls ? "HTTPS" : "HTTP"
-
-  default_action {
-    type = "fixed-response"
-
-    # Return a 404 status code by default
-    fixed_response {
-      content_type = "text/plain"
-      status_code  = "404"
-    }
-  }
-
-  tags = var.additional_tags
-}
-*/
-
 module "listeners" {
   source = "./listener"
 
@@ -29,18 +8,15 @@ module "listeners" {
   alb_arn           = aws_lb.alb.arn
   security_group_id = aws_security_group.alb.id
 
-  settings = each.value
+  #settings = each.value
+
+  port            = each.value.port
+  tls             = each.value.tls
+  allowed_ips     = each.value.allowed_ips
+  allowed_subnets = each.value.allowed_subnets
+  #use_tls      = each.value.use_tls
+  #force_tls    = each.value.force_tls
+  #default_cert = each.value.default_cert
 
   additional_tags = var.additional_tags
-
-  /*
-  port             = each.value.port
-  use_tls          = each.value.use_tls
-  force_tls        = each.value.force_tls
-  default_cert     = each.value.default_cert
-  additional_certs = optional(list(string))
-  allowed_ips      = list(string)
-  allowed_subnets  = list(string)
-  */
-
 }

--- a/bloom-instance/alb/listener.tf
+++ b/bloom-instance/alb/listener.tf
@@ -17,6 +17,7 @@ module "listeners" {
   tls             = each.value.tls
   allowed_ips     = each.value.allowed_ips
   allowed_subnets = each.value.allowed_subnets
+  default_action = each.value.default_action
 
   additional_tags = var.additional_tags
 }

--- a/bloom-instance/alb/listener.tf
+++ b/bloom-instance/alb/listener.tf
@@ -17,7 +17,7 @@ module "listeners" {
   tls             = each.value.tls
   allowed_ips     = each.value.allowed_ips
   allowed_subnets = each.value.allowed_subnets
-  default_action = each.value.default_action
+  default_action  = each.value.default_action
 
   additional_tags = var.additional_tags
 }

--- a/bloom-instance/alb/listener/inputs.tf
+++ b/bloom-instance/alb/listener/inputs.tf
@@ -33,8 +33,7 @@ variable "port" {
 }
 
 variable "default_action" {
-  type    = string
-  default = "404"
+  type = string
 
   validation {
     condition     = contains(["force-tls", "404"], var.default_action)

--- a/bloom-instance/alb/listener/inputs.tf
+++ b/bloom-instance/alb/listener/inputs.tf
@@ -17,15 +17,26 @@ variable "security_group_id" {
   description = "The Security Group to attach ingress rules to"
 }
 
+variable "port" {
+  type        = number
+  description = "The port to listen on"
+
+  validation {
+    condition     = var.port > 0 && var.port <= 65535
+    error_message = "Port number must be in valid range"
+  }
+}
+
+/*
 variable "settings" {
   type = object({
-    port             = number
-    use_tls          = bool
-    force_tls        = optional(bool)
-    default_cert     = optional(string)
-    additional_certs = optional(list(string))
-    allowed_ips      = optional(list(string), [])
-    allowed_subnets  = optional(list(string), [])
+    ///port = number
+    //use_tls          = bool
+    //force_tls        = optional(bool)
+    //default_cert     = optional(string)
+    //additional_certs = optional(list(string))
+    allowed_ips     = optional(list(string), [])
+    allowed_subnets = optional(list(string), [])
   })
   description = "The listeners to create"
 
@@ -38,6 +49,38 @@ variable "settings" {
     condition     = !(var.settings.use_tls && var.settings.default_cert == null)
     error_message = "default_cert is required if use_tls is true"
   }
+}
+*/
+
+variable "default_action" {
+  type    = string
+  default = "404"
+
+  validation {
+    condition     = contains(["force-tls", "404"], var.default_action)
+    error_message = "default_action must be one of [force-tls, 404]"
+  }
+}
+
+variable "tls" {
+  type = object({
+    enable           = optional(bool, true)
+    default_cert     = string
+    additional_certs = optional(list(string))
+  })
+
+  default     = null
+  description = "TLS settings"
+}
+
+variable "allowed_ips" {
+  type        = list(string)
+  description = "CIDR blocks to allow access from"
+}
+
+variable "allowed_subnets" {
+  type        = list(string)
+  description = "Subnet groups to allow access from"
 }
 
 variable "additional_tags" {

--- a/bloom-instance/alb/listener/inputs.tf
+++ b/bloom-instance/alb/listener/inputs.tf
@@ -6,6 +6,19 @@ variable "certs" {
 }
 */
 
+variable "subnets" {
+  type = map(object({
+    id = string
+  }))
+  description = "A map of the available subnets"
+}
+
+variable "subnet_group" {
+  type        = string
+  description = "The identifier for the subnet group to place the ALB into"
+}
+
+
 variable "settings" {
   type = object({
     port             = number
@@ -14,6 +27,7 @@ variable "settings" {
     default_cert     = optional(string)
     additional_certs = optional(list(string))
     allowed_ips      = list(string)
+    allowed_subnets  = list(string)
   })
   default     = null
   description = "The listeners to create"

--- a/bloom-instance/alb/listener/inputs.tf
+++ b/bloom-instance/alb/listener/inputs.tf
@@ -1,23 +1,21 @@
 
-/*
-variable "certs" {
-  type        = map(string)
-  description = "ARNs for TLS certificates to apply to secure listeners"
-}
-*/
-
 variable "subnets" {
-  type = map(object({
-    id = string
-  }))
-  description = "A map of the available subnets"
+  type = map(list(object({
+    id   = string
+    cidr = string
+  })))
+  description = "A map of available subnets"
 }
 
-variable "subnet_group" {
+variable "alb_arn" {
   type        = string
-  description = "The identifier for the subnet group to place the ALB into"
+  description = "The ALB to attach the listener to"
 }
 
+variable "security_group_id" {
+  type        = string
+  description = "The Security Group to attach ingress rules to"
+}
 
 variable "settings" {
   type = object({
@@ -26,19 +24,18 @@ variable "settings" {
     force_tls        = optional(bool)
     default_cert     = optional(string)
     additional_certs = optional(list(string))
-    allowed_ips      = list(string)
-    allowed_subnets  = list(string)
+    allowed_ips      = optional(list(string), [])
+    allowed_subnets  = optional(list(string), [])
   })
-  default     = null
   description = "The listeners to create"
 
   validation {
-    condition     = var.defintion.port > 0 && var.defintion.port <= 65535
+    condition     = var.settings.port > 0 && var.settings.port <= 65535
     error_message = "Port numbers must be in valid range"
   }
 
   validation {
-    condition     = var.defintion.use_tls && var.defintion.default_cert == null
+    condition     = !(var.settings.use_tls && var.settings.default_cert == null)
     error_message = "default_cert is required if use_tls is true"
   }
 }

--- a/bloom-instance/alb/listener/inputs.tf
+++ b/bloom-instance/alb/listener/inputs.tf
@@ -1,0 +1,36 @@
+
+/*
+variable "certs" {
+  type        = map(string)
+  description = "ARNs for TLS certificates to apply to secure listeners"
+}
+*/
+
+variable "settings" {
+  type = object({
+    port             = number
+    use_tls          = bool
+    force_tls        = optional(bool)
+    default_cert     = optional(string)
+    additional_certs = optional(list(string))
+    allowed_ips      = list(string)
+  })
+  default     = null
+  description = "The listeners to create"
+
+  validation {
+    condition     = var.defintion.port > 0 && var.defintion.port <= 65535
+    error_message = "Port numbers must be in valid range"
+  }
+
+  validation {
+    condition     = var.defintion.use_tls && var.defintion.default_cert == null
+    error_message = "default_cert is required if use_tls is true"
+  }
+}
+
+variable "additional_tags" {
+  type        = map(string)
+  default     = null
+  description = "Additional tags to apply to the listener"
+}

--- a/bloom-instance/alb/listener/inputs.tf
+++ b/bloom-instance/alb/listener/inputs.tf
@@ -7,6 +7,11 @@ variable "subnets" {
   description = "A map of available subnets"
 }
 
+variable "cert_map" {
+  type        = map(string)
+  description = "ARNs for TLS certificates to apply to secure listeners"
+}
+
 variable "alb_arn" {
   type        = string
   description = "The ALB to attach the listener to"
@@ -27,31 +32,6 @@ variable "port" {
   }
 }
 
-/*
-variable "settings" {
-  type = object({
-    ///port = number
-    //use_tls          = bool
-    //force_tls        = optional(bool)
-    //default_cert     = optional(string)
-    //additional_certs = optional(list(string))
-    allowed_ips     = optional(list(string), [])
-    allowed_subnets = optional(list(string), [])
-  })
-  description = "The listeners to create"
-
-  validation {
-    condition     = var.settings.port > 0 && var.settings.port <= 65535
-    error_message = "Port numbers must be in valid range"
-  }
-
-  validation {
-    condition     = !(var.settings.use_tls && var.settings.default_cert == null)
-    error_message = "default_cert is required if use_tls is true"
-  }
-}
-*/
-
 variable "default_action" {
   type    = string
   default = "404"
@@ -71,6 +51,11 @@ variable "tls" {
 
   default     = null
   description = "TLS settings"
+
+  validation {
+    condition     = var.tls != null && !(var.tls.enable && var.tls.default_cert == null)
+    error_message = "default_cert is required if tls.enable is true"
+  }
 }
 
 variable "allowed_ips" {

--- a/bloom-instance/alb/listener/main.tf
+++ b/bloom-instance/alb/listener/main.tf
@@ -1,0 +1,23 @@
+
+locals {
+  use_tls   = var.settings.use_tls
+  force_tls = local.use_tls && var.settings.force_tls
+}
+
+resource "aws_lb_listener" "listener" {
+  load_balancer_arn = aws_lb.alb.arn
+  port              = var.settings.port
+  protocol          = local.use_tls ? "HTTPS" : "HTTP"
+
+  default_action {
+    type = "fixed-response"
+
+    # Return a 404 status code by default
+    fixed_response {
+      content_type = "text/plain"
+      status_code  = "404"
+    }
+  }
+
+  tags = var.additional_tags
+}

--- a/bloom-instance/alb/listener/main.tf
+++ b/bloom-instance/alb/listener/main.tf
@@ -2,6 +2,9 @@
 locals {
   use_tls   = var.settings.use_tls
   force_tls = local.use_tls && var.settings.force_tls
+
+  allowed_ips     = var.settings.allowed_ips
+  allowed_subnets = var.settings.allowed_subnets
 }
 
 resource "aws_lb_listener" "listener" {
@@ -18,6 +21,20 @@ resource "aws_lb_listener" "listener" {
       status_code  = "404"
     }
   }
+
+  tags = var.additional_tags
+}
+
+# Create one ingress rule for each listener/port/ip combination
+resource "aws_vpc_security_group_ingress_rule" "ingress" {
+  for_each = { for pm in local.port_mappings : "${pm.name}-${pm.port}-${pm.cidr}" => pm }
+
+  security_group_id = aws_security_group.alb.id
+
+  cidr_ipv4   = each.value.cidr
+  from_port   = each.value.port
+  to_port     = each.value.port
+  ip_protocol = "tcp"
 
   tags = var.additional_tags
 }

--- a/bloom-instance/alb/listener/main.tf
+++ b/bloom-instance/alb/listener/main.tf
@@ -75,24 +75,7 @@ resource "aws_lb_listener" "listener" {
         status_code = redirect.value.status_code
       }
     }
-
-    # # Return a 404 status code by default
-    # fixed_response {
-    #   content_type = "text/plain"
-    #   status_code  = "404"
-    # }
   }
-
-  # default_action {
-  #   type = "redirect"
-
-  #   # Redirect the client to the HTTPS version of the site
-  #   redirect {
-  #     protocol    = "HTTPS"
-  #     port        = 443 # TODO: make this configurable
-  #     status_code = "HTTP_302"
-  #   }
-  # }
 
   tags = var.additional_tags
 }

--- a/bloom-instance/alb/listener/outputs.tf
+++ b/bloom-instance/alb/listener/outputs.tf
@@ -1,0 +1,4 @@
+
+output "arn" {
+  value = aws_lb_listener.listener.arn
+}

--- a/bloom-instance/alb/locals.tf
+++ b/bloom-instance/alb/locals.tf
@@ -1,18 +1,5 @@
 
 locals {
-  /*
-  # Convert listeners[name].allowed_ips to a flat list of tuples for ingress rules
-  port_mappings = flatten([
-    for k, v in var.listeners : [
-      for i, ip in v.allowed_ips : {
-        name = k
-        port = v.port
-        cidr = ip
-      }
-    ]
-  ])
-  */
-
   # The prefix to prepend to log entries for this ALB
   log_prefix = "${var.name_prefix}/alb/${var.name}"
 }

--- a/bloom-instance/alb/locals.tf
+++ b/bloom-instance/alb/locals.tf
@@ -1,5 +1,6 @@
 
 locals {
+  /*
   # Convert listeners[name].allowed_ips to a flat list of tuples for ingress rules
   port_mappings = flatten([
     for k, v in var.listeners : [
@@ -10,6 +11,7 @@ locals {
       }
     ]
   ])
+  */
 
   # The prefix to prepend to log entries for this ALB
   log_prefix = "${var.name_prefix}/alb/${var.name}"

--- a/bloom-instance/alb/outputs.tf
+++ b/bloom-instance/alb/outputs.tf
@@ -9,7 +9,8 @@ output "security_group" {
 }
 
 output "listeners" {
-  value = aws_lb_listener.alb_listeners
+  #value = aws_lb_listener.alb_listeners
+  value = module.listeners
 }
 
 # Used for generating log bucket policy

--- a/bloom-instance/alb/sg.tf
+++ b/bloom-instance/alb/sg.tf
@@ -20,6 +20,7 @@ resource "aws_vpc_security_group_egress_rule" "https" {
   tags = var.additional_tags
 }
 
+/*
 # Create one ingress rule for each listener/port/ip combination
 resource "aws_vpc_security_group_ingress_rule" "ingress" {
   for_each = { for pm in local.port_mappings : "${pm.name}-${pm.port}-${pm.cidr}" => pm }
@@ -33,3 +34,4 @@ resource "aws_vpc_security_group_ingress_rule" "ingress" {
 
   tags = var.additional_tags
 }
+*/

--- a/bloom-instance/alb/sg.tf
+++ b/bloom-instance/alb/sg.tf
@@ -19,19 +19,3 @@ resource "aws_vpc_security_group_egress_rule" "https" {
 
   tags = var.additional_tags
 }
-
-/*
-# Create one ingress rule for each listener/port/ip combination
-resource "aws_vpc_security_group_ingress_rule" "ingress" {
-  for_each = { for pm in local.port_mappings : "${pm.name}-${pm.port}-${pm.cidr}" => pm }
-
-  security_group_id = aws_security_group.alb.id
-
-  cidr_ipv4   = each.value.cidr
-  from_port   = each.value.port
-  to_port     = each.value.port
-  ip_protocol = "tcp"
-
-  tags = var.additional_tags
-}
-*/

--- a/bloom-instance/dns.tf
+++ b/bloom-instance/dns.tf
@@ -12,7 +12,7 @@ module "public_site_records" {
     for domain in site.domains : "${key}-${domain}" => {
       name   = domain
       type   = "CNAME"
-      values = [module.public_alb.dns_name]
+      values = [module.albs[site.alb].dns_name]
       ttl    = module.dns.default_ttl
     }
   }]...)
@@ -28,7 +28,7 @@ module "partner_site_records" {
   for_each = { for domain in var.partner_site.domains : domain => {
     name   = domain
     type   = "CNAME"
-    values = [module.public_alb.dns_name]
+    values = [module.albs[var.partner_site.alb].dns_name]
     ttl    = module.dns.default_ttl
     }
   }

--- a/bloom-instance/logging.tf
+++ b/bloom-instance/logging.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket_policy" "log_bucket_policy" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = [for name, alb in module.albs :
       {
         Sid = "AllowWritesToLogBucket"
         Action = [
@@ -17,8 +17,8 @@ resource "aws_s3_bucket_policy" "log_bucket_policy" {
         Principal = {
           AWS = local.elb_service_account_arn
         }
-        Resource = "arn:aws:s3:::${aws_s3_bucket.logging_bucket.bucket}/${module.public_alb.log_prefix}/AWSLogs/${local.current_account_id}/*",
-      },
+        Resource = "arn:aws:s3:::${aws_s3_bucket.logging_bucket.bucket}/${alb.log_prefix}/AWSLogs/${local.current_account_id}/*",
+      }
     ]
   })
 }

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -56,40 +56,6 @@ module "network" {
   use_ngw     = var.use_ngw
 }
 
-module "albs" {
-  source   = "./alb"
-  for_each = { for name, value in var.albs : name => value }
-
-  name_prefix = local.default_name
-  name        = each.key
-  vpc_id      = module.network.vpc.id
-
-  # TODO: combine all subnet IDs in list
-  subnet_ids = [for subnet in module.network.subnets[each.value.subnets[0]] : subnet.id]
-
-  enable_logging = each.value.enable_logging
-  log_bucket     = aws_s3_bucket.logging_bucket.bucket
-
-  listeners = each.value.listeners
-
-  /*
-  listeners = {
-    public = {
-      port        = 80
-      use_tls     = false
-      allowed_ips = ["0.0.0.0/0"]
-    }
-
-    # internal is here just to provide an easy path forward if we want an internal route to services
-    internal = {
-      port        = 8080
-      use_tls     = false
-      allowed_ips = [for subnet in module.network.subnets.app : subnet.cidr_block]
-    }
-  }
-  */
-}
-
 # There may be multiple public sites
 module "public_sites" {
   for_each = { for idx, srv in var.public_sites : idx => srv }

--- a/bloom-instance/network/subnets/outputs.tf
+++ b/bloom-instance/network/subnets/outputs.tf
@@ -2,8 +2,8 @@
 output "subnets" {
   #value = aws_subnet.subnets
   value = [for subnet in aws_subnet.subnets : {
-    id  = subnet.id
-    az  = subnet.availability_zone
-    ips = subnet.cidr_block
+    id   = subnet.id
+    az   = subnet.availability_zone
+    cidr = subnet.cidr_block
   }]
 }

--- a/bloom-instance/network/subnets/outputs.tf
+++ b/bloom-instance/network/subnets/outputs.tf
@@ -1,4 +1,9 @@
 
 output "subnets" {
-  value = aws_subnet.subnets
+  #value = aws_subnet.subnets
+  value = [for subnet in aws_subnet.subnets : {
+    id  = subnet.id
+    az  = subnet.availability_zone
+    ips = subnet.cidr_block
+  }]
 }

--- a/bloom-instance/services/base-service/inputs.tf
+++ b/bloom-instance/services/base-service/inputs.tf
@@ -14,6 +14,10 @@ variable "service_definition" {
     # The name of the service (must be unique)
     name = string
 
+    # The identifier for the ALB to use (ie "default")
+    # This is used elsewhere to look up ALB info
+    alb = string
+
     # The amount of CPU to allocate to the service
     cpu = optional(number, 256)
 

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -77,20 +77,29 @@ certs = {
 }
 
 albs = {
-  "default" = {
+  public = {
     subnet_group = "public"
 
     listeners = {
       http = {
-        port        = 80
-        use_tls     = false
-        allowed_ips = ["0.0.0.0/0"]
+        port           = 80
+        default_action = "force-tls"
+        allowed_ips    = ["0.0.0.0/0"]
       }
 
-      # internal is here just to provide an easy path forward if we want an internal route to services
-      internal = {
-        port            = 8080
-        use_tls         = false
+      https = {
+        port        = 443
+        default_action = "404"
+        allowed_ips = ["0.0.0.0/0"]
+
+        tls = {
+          default_cert     = "doorway"
+          additional_certs = ["doorway-external"]
+        }
+      }
+
+      backend = {
+        port            = 3100
         allowed_subnets = ["app"]
       }
     }

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -53,9 +53,31 @@ dns = {
   }
 }
 
+albs = {
+  "default" = {
+    subnet_group = "public"
+
+    listeners = {
+      http = {
+        port        = 80
+        use_tls     = false
+        allowed_ips = ["0.0.0.0/0"]
+      }
+
+      # internal is here just to provide an easy path forward if we want an internal route to services
+      internal = {
+        port            = 8080
+        use_tls         = false
+        allowed_subnets = ["app"]
+      }
+    }
+  }
+}
+
 public_sites = [
   {
     name = "public"
+    alb   = "default"
     cpu = 256
     ram = 512
     image = "nginx:latest"
@@ -81,6 +103,7 @@ public_sites = [
 
 partner_site = {
   name = "partner"
+  alb   = "default"
   cpu = 256
   ram = 512
   image = "nginx:latest"

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -77,7 +77,7 @@ certs = {
 }
 
 albs = {
-  public = {
+  default = {
     subnet_group = "public"
 
     listeners = {

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -120,7 +120,15 @@ variable "albs" {
       allowed_ips     = optional(list(string))
       allowed_subnets = optional(list(string))
 
-      tls = optional(any)
+      tls = optional(object({
+        enable           = optional(bool, true)
+        default_cert     = string
+        additional_certs = optional(list(string))
+        }), {
+        enable           = false
+        default_cert     = null
+        additional_certs = []
+      })
     }))
   }))
   description = "Settings for managing ALBs"

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -115,7 +115,7 @@ variable "albs" {
     # See alb/listeners/inputs.tf for more info
     listeners = map(object({
       port           = number
-      default_action = optional(string)
+      default_action = optional(string, "404")
 
       allowed_ips     = optional(list(string))
       allowed_subnets = optional(list(string))

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -107,11 +107,13 @@ variable "dns" {
 
 variable "albs" {
   type = map(object({
-    subnets        = list(string)
+    subnet_group   = string
     enable_logging = optional(bool, true)
+    internal       = optional(bool)
+
     listeners = map(object({
       # The port to listen on
-      port             = number
+      port = number
 
       # TLS settings
       use_tls          = bool
@@ -119,8 +121,8 @@ variable "albs" {
       additional_certs = optional(list(string))
 
       # Security Group settings
-      allowed_ips      = optional(list(string))
-      allowed_subnets  = optional(list(string))
+      allowed_ips     = optional(list(string))
+      allowed_subnets = optional(list(string))
     }))
   }))
   description = "Settings for managing ALBs"

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -107,22 +107,20 @@ variable "dns" {
 
 variable "albs" {
   type = map(object({
+    # See alb/inputs.tf for more info
     subnet_group   = string
     enable_logging = optional(bool, true)
     internal       = optional(bool)
 
+    # See alb/listeners/inputs.tf for more info
     listeners = map(object({
-      # The port to listen on
-      port = number
+      port           = number
+      default_action = optional(string)
 
-      # TLS settings
-      use_tls          = bool
-      default_cert     = optional(string)
-      additional_certs = optional(list(string))
-
-      # Security Group settings
       allowed_ips     = optional(list(string))
       allowed_subnets = optional(list(string))
+
+      tls = optional(any)
     }))
   }))
   description = "Settings for managing ALBs"

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -105,6 +105,27 @@ variable "dns" {
   description = "Settings for managing DNS zones and records"
 }
 
+variable "albs" {
+  type = map(object({
+    subnets        = list(string)
+    enable_logging = optional(bool, true)
+    listeners = map(object({
+      # The port to listen on
+      port             = number
+
+      # TLS settings
+      use_tls          = bool
+      default_cert     = optional(string)
+      additional_certs = optional(list(string))
+
+      # Security Group settings
+      allowed_ips      = optional(list(string))
+      allowed_subnets  = optional(list(string))
+    }))
+  }))
+  description = "Settings for managing ALBs"
+}
+
 variable "public_sites" {
   # See services/base-service/inputs.tf for object structure
   type        = any


### PR DESCRIPTION
I moved the ALB config from hard-coded values in the main.tf to an object defined in the vars.tf file.  I also moved the listener resource to a separate module to simplify listener configuration, added TLS support using the recently added cert module, and moved the calling of the ALB module out of the main.tf and into a separate alb.tf file to keep things more organized and easier to locate.

Resolves #79 