### PR TITLE
feat: add S3 bucket CORS policy and bucket policy

### DIFF
--- a/bloom-instance/s3.tf
+++ b/bloom-instance/s3.tf
@@ -1,3 +1,40 @@
 resource "aws_s3_bucket" "user_upload_bucket" {
   bucket_prefix = "${var.name_prefix}-user-uploads"
 }
+
+resource "aws_s3_bucket_cors_configuration" "user_upload_cors_config" {
+  bucket = aws_s3_bucket.user_upload_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "GET"]
+    allowed_origins = ["http://localhost:3001"]
+    expose_headers  = []
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_public_access" {
+  bucket = aws_s3_bucket.user_upload_bucket.id
+  policy = data.aws_iam_policy_document.allow_public_access_policy.json
+}
+
+data "aws_iam_policy_document" "allow_public_access_policy" {
+  statement {
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.user_upload_bucket.arn,
+      "${aws_s3_bucket.user_upload_bucket.arn}/*",
+    ]
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/metrotranscom/doorway/issues/49.

Add CORS policy to the S3 user uploads bucket that allows cross origin requests from the partners site URL for GET and PUT.
Add bucket policy that allows public access for GetObject and PutObject for objects in the user uploads bucket.

I was not able to run terraform plan to verify the changes because it seems like I don't have the required permissions for some existing configuration:

Error: reading IAM Role (AWSServiceRoleForRDS): AccessDenied: User: arn:aws:iam::364076391763:user/inesfranch@google.com is not authorized to perform: iam:GetRole on resource: role AWSServiceRoleForRDS because no identity-based policy allows the iam:GetRole action