### PR TITLE
ci: use CodeDeploy

### DIFF
--- a/bloom-instance/ecs/service/ecs.tf
+++ b/bloom-instance/ecs/service/ecs.tf
@@ -31,5 +31,9 @@ resource "aws_ecs_service" "service" {
     ignore_changes = [desired_count]
   }
 
+  deployment_controller {
+    type = "CODE_DEPLOY"
+  }
+
   tags = var.additional_tags
 }


### PR DESCRIPTION
resolving an error when building the ci/cd pipeline
```
Error: Error creating CodeDeploy deployment group: InvalidECSServiceException: Deployment group's ECS service must be configured for a CODE_DEPLOY deployment controller.
```