### PR TITLE
fix: add aws_s3_public_access_block for public uploads

### DIFF
--- a/bloom-instance/s3.tf
+++ b/bloom-instance/s3.tf
@@ -10,6 +10,15 @@ resource "aws_s3_bucket" "static_content" {
   bucket_prefix = "${var.name_prefix}-static-content"
 }
 
+resource "aws_s3_bucket_public_access_block" "public_uploads" {
+  bucket = aws_s3_bucket.public_uploads.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
 # Allow anyone to read from the public uploads bucket
 resource "aws_s3_bucket_policy" "public_uploads" {
   bucket = aws_s3_bucket.public_uploads.id
@@ -23,8 +32,10 @@ resource "aws_s3_bucket_policy" "public_uploads" {
         ]
         Effect    = "Allow"
         Principal = "*"
-        Resource  = "arn:aws:s3:${var.aws_region}::${aws_s3_bucket.public_uploads.bucket}/*",
+        Resource  = "${aws_s3_bucket.public_uploads.arn}/*",
       },
     ]
   })
+
+  depends_on = [aws_s3_bucket_public_access_block.public_uploads]
 }


### PR DESCRIPTION
The bucket policy that was added in a previous PR (#93) can't actually be applied due to additional layers of protection added by AWS.  This PR disables those protections to prevent the `Access Denied` error that would occur otherwise.

[plan.txt](https://github.com/metrotranscom/doorway-infra/files/11357696/plan.txt)
