### PR TITLE
Refactor network config

### DIFF
--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -46,12 +46,3 @@ locals {
   # The Account ID for the AWS ELB service in this region
   elb_service_account_arn = data.aws_elb_service_account.current.arn
 }
-
-module "network" {
-  source = "./network"
-
-  name_prefix = local.default_name
-  vpc_cidr    = var.vpc_cidr
-  subnet_map  = var.subnet_map
-  use_ngw     = var.use_ngw
-}

--- a/bloom-instance/network.tf
+++ b/bloom-instance/network.tf
@@ -1,0 +1,7 @@
+module "network" {
+  source = "./network"
+
+  name_prefix   = local.default_name
+  vpc_cidr      = var.network.vpc_cidr
+  subnet_groups = var.network.subnet_groups
+}

--- a/bloom-instance/network/locals.tf
+++ b/bloom-instance/network/locals.tf
@@ -1,11 +1,23 @@
 
-//data "aws_default_tags" "current" {}
-
 locals {
-  #tags = var.tags != null ? var.tags : data.aws_default_tags.current.tags
   default_name = "${var.name_prefix}:${var.name}"
 
-  ngw_count = var.use_ngw ? 1 : 0
+  # Get a list of all cases where a group needs an NGW
+  need_ngw = [for group in var.subnet_groups : group.use_ngw]
+
+  # If any of them do need one, make sure to create it
+  create_ngw = contains(local.need_ngw, true)
+  ngw_count  = local.create_ngw ? 1 : 0
+
+  # Validation enforces that there must be one public subnet group
+  # Store the id for that group here
+  public_subnet_group_id = coalesce([for id, group in var.subnet_groups : id if group.is_public == true]...)
+
+  # and a reference to that group here
+  public_subnet_group = var.subnet_groups[local.public_subnet_group_id]
+
+  # The rest of the groups (all private) go here
+  private_subnet_groups = { for id, group in var.subnet_groups : id => group if group.is_public != true }
 
   # Take the default set of tags and add a Name tag.
   # Not all resources use the Name tag, but this makes it easier for the ones that do

--- a/bloom-instance/network/outputs.tf
+++ b/bloom-instance/network/outputs.tf
@@ -3,10 +3,17 @@ output "vpc" {
   value = aws_vpc.vpc
 }
 
+# a list of just the public subnets
+output "public_subnets" {
+  value = module.public_subnet_group.subnets
+}
+
+# a map of all subnets indexed by subnet group id (including public)
 output "subnets" {
-  value = {
-    public = module.public.subnets
-    app    = module.app.subnets
-    data   = module.data.subnets
-  }
+  value = merge(
+    { for id, group in module.private_subnet_groups : id => group.subnets },
+    {
+      "${local.public_subnet_group_id}" : module.public_subnet_group.subnets
+    }
+  )
 }

--- a/bloom-instance/network/subnets.tf
+++ b/bloom-instance/network/subnets.tf
@@ -1,37 +1,32 @@
 
-module "public" {
+# the public group has to be created separately to avoid circular dependencies
+# subnets->ngw->igw->subnets
+module "public_subnet_group" {
   source = "./subnets"
 
-  name            = "Public"
   name_prefix     = var.name_prefix
   vpc_id          = aws_vpc.vpc.id
-  subnet_mappings = var.subnet_map.public
   additional_tags = var.additional_tags
+
+  name            = local.public_subnet_group.name
+  subnet_mappings = local.public_subnet_group.subnets
 
   gateway_type = "igw"
   igw_id       = aws_internet_gateway.igw.id
 }
 
-# TODO: make sure of AZ/NGW alignment if more than one NGW
-module "app" {
+module "private_subnet_groups" {
   source = "./subnets"
 
-  name            = "App"
+  for_each = { for id, group in local.private_subnet_groups : id => group }
+
   name_prefix     = var.name_prefix
   vpc_id          = aws_vpc.vpc.id
-  subnet_mappings = var.subnet_map.app
   additional_tags = var.additional_tags
 
-  gateway_type = "ngw"
-  ngw_id       = aws_nat_gateway.ngw[0].id
-}
+  name            = each.value.name
+  subnet_mappings = each.value.subnets
 
-module "data" {
-  source = "./subnets"
-
-  name            = "Data"
-  name_prefix     = var.name_prefix
-  vpc_id          = aws_vpc.vpc.id
-  subnet_mappings = var.subnet_map.data
-  additional_tags = var.additional_tags
+  gateway_type = each.value.use_ngw ? "ngw" : "none"
+  ngw_id       = each.value.use_ngw ? aws_nat_gateway.ngw[0].id : null
 }

--- a/bloom-instance/network/subnets/main.tf
+++ b/bloom-instance/network/subnets/main.tf
@@ -1,8 +1,7 @@
 
-//data "aws_default_tags" "current" {}
-
 locals {
+  # Using gateway_type rather than the presence of IDs prevents this issue in TF:
+  # `The "count" value depends on resource attributes that cannot be determined until apply`
   add_ngw = var.gateway_type == "ngw" ? true : false
   add_igw = var.gateway_type == "igw" ? true : false
-  //tags    = var.tags != null ? var.tags : data.aws_default_tags.current.tags
 }

--- a/bloom-instance/network/subnets/routes.tf
+++ b/bloom-instance/network/subnets/routes.tf
@@ -10,7 +10,7 @@ resource "aws_route_table" "route_table" {
   )
 }
 
-# Only set if var.ngw_id is not null
+# Only set if gateway_type == "ngw"
 resource "aws_route" "ngw_route" {
   count                  = local.add_ngw ? 1 : 0
   route_table_id         = aws_route_table.route_table.id
@@ -18,7 +18,7 @@ resource "aws_route" "ngw_route" {
   nat_gateway_id         = var.ngw_id
 }
 
-# Only set if var.igw_id is not null
+# Only set if gateway_type == "igw"
 resource "aws_route" "igw_route" {
   count                  = local.add_igw ? 1 : 0
   route_table_id         = aws_route_table.route_table.id

--- a/bloom-instance/network/vpc.tf
+++ b/bloom-instance/network/vpc.tf
@@ -4,22 +4,26 @@ resource "aws_vpc" "vpc" {
   tags       = local.tags_with_name
 }
 
+# mandatory since we require exactly one set of public subnets
 resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.vpc.id
   tags   = local.tags_with_name
 }
 
+# only needed if at least one group needs an ngw
 resource "aws_eip" "ngw_eip" {
   count = local.ngw_count
   vpc   = true
   tags  = local.tags_with_name
 }
 
+# only needed if at least one group needs an ngw
 resource "aws_nat_gateway" "ngw" {
   count         = local.ngw_count
   allocation_id = aws_eip.ngw_eip[count.index].id
 
-  subnet_id = module.public.subnets[count.index].id
+  # use the first subnet in the public subnet group
+  subnet_id = module.public_subnet_group.subnets[count.index].id
   tags      = local.tags_with_name
 
   depends_on = [aws_internet_gateway.igw]

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -4,36 +4,56 @@ name_prefix = "doorway"
 team_name = "doorway"
 aws_region = "us-west-1"
 sdlc_stage = "dev"
-subnet_map = {
-    "public" = [
-      {
-        az   = "us-west-1a",
-        cidr = "10.0.0.0/24"
-      },
-      {
-        az   = "us-west-1c",
-        cidr = "10.0.1.0/24"
-      }
-    ]
-    "app" = [
-      {
-        az   = "us-west-1a",
-        cidr = "10.0.2.0/24"
-      },
-      {
-        az   = "us-west-1c",
-        cidr = "10.0.3.0/24"
-      }
-    ]
-    "data" = [
-      {
-        az   = "us-west-1a",
-        cidr = "10.0.4.0/24"
-      }
-    ]
+
+network = {
+  vpc_cidr = "10.0.0.0/16"
+
+  subnet_groups = {
+    "public" = {
+      name      = "Public"
+      is_public = true
+      subnets = [
+        {
+          az   = "us-west-1a",
+          cidr = "10.0.0.0/24"
+        },
+        {
+          az   = "us-west-1c",
+          cidr = "10.0.1.0/24"
+        }
+      ]
+    }
+
+    "app" = {
+      name    = "App"
+      use_ngw = true
+      subnets = [
+        {
+          az   = "us-west-1a",
+          cidr = "10.0.2.0/24"
+        },
+        {
+          az   = "us-west-1c",
+          cidr = "10.0.3.0/24"
+        }
+      ]
+    }
+
+    "data" = {
+      name = "Data"
+      subnets = [
+        {
+          az   = "us-west-1a",
+          cidr = "10.0.4.0/24"
+        },
+        {
+          az   = "us-west-1c",
+          cidr = "10.0.5.0/24"
+        }
+      ]
+    }
   }
-vpc_cidr = "10.0.0.0/16"
-use_ngw = true
+}
 
 dns = {
   default_ttl = 60

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -59,49 +59,17 @@ variable "sdlc_stage" {
   }
 }
 
-variable "subnet_map" {
+variable "network" {
   type = object({
-    public = list(object({
-      az   = string
-      cidr = string
-    }))
+    vpc_cidr = string
 
-    app = list(object({
-      az   = string
-      cidr = string
-    }))
-
-    data = list(object({
-      az   = string
-      cidr = string
-    }))
+    # See ./network/inputs.tf for object structure
+    subnet_groups = any
   })
-  description = "The subnets to create in our VPC"
-}
-
-variable "vpc_cidr" {
-  type        = string
-  description = "The IP addresses to allocate to our VPC, e.g. 10.0.0.0/16"
-}
-
-variable "use_ngw" {
-  type        = bool
-  description = "Whether to set up a NAT Gateway in the VPC"
 }
 
 variable "dns" {
-  type = any
-  /*
-  type = object({
-    zones = map(object({
-      # If this zone already exists and shouldn't be created, add the zone ID here
-      zone_id = optional(string)
-
-      # Records that should be added to this zone beyond what are created automatically
-      #additional_records = optional(any)
-    }))
-  })
-  */
+  type        = any
   description = "Settings for managing DNS zones and records"
 }
 


### PR DESCRIPTION
This one got away from me a little bit.  I originally set out to just resolve #67 but ended up changing the way that the network module creates subnets to make it more dynamic.  This was part of the plan anyway (note the references to `subnet_group` in the alb, database, and service vars), but one thing just sort of led to another and here we are.

This does change the expected vars in the tfvars file (see template), so a followup PR will be made to adjust the actual configs once merged.

[plan.txt](https://github.com/metrotranscom/doorway-infra/files/11357729/plan.txt)
