### PR TITLE
ci: increase build timeout

### DIFF
--- a/app-codepipeline/codepipeline.tf
+++ b/app-codepipeline/codepipeline.tf
@@ -113,6 +113,8 @@ resource "aws_codebuild_project" "default" {
     type      = "CODEPIPELINE"
     buildspec = "ci/buildspec_${var.repo.branch}.yml"
   }
+
+  build_timeout = "120"
 }
 
 resource "aws_codebuild_project" "deploy_ecs" {


### PR DESCRIPTION
This is required, since we're not yet building in parallel. 