### PR TITLE
ci: parallel build in codepipeline

### DIFF
--- a/app-codepipeline/build_backend.tf
+++ b/app-codepipeline/build_backend.tf
@@ -1,0 +1,36 @@
+resource "aws_codebuild_project" "backend" {
+  name         = "${var.name_prefix}-codebuild-backend"
+  service_role = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:6.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    dynamic "environment_variable" {
+      for_each = local.build_env_vars
+      content {
+        name  = environment_variable.value["name"]
+        value = environment_variable.value["value"]
+      }
+    }
+  }
+  logs_config {
+    cloudwatch_logs {
+      status = "ENABLED"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = "ci/buildspec_${var.repo.branch}_backend.yml"
+  }
+
+  build_timeout = "120"
+}

--- a/app-codepipeline/build_partners.tf
+++ b/app-codepipeline/build_partners.tf
@@ -1,0 +1,36 @@
+resource "aws_codebuild_project" "partners" {
+  name         = "${var.name_prefix}-codebuild-partners"
+  service_role = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:6.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    dynamic "environment_variable" {
+      for_each = local.build_env_vars
+      content {
+        name  = environment_variable.value["name"]
+        value = environment_variable.value["value"]
+      }
+    }
+  }
+  logs_config {
+    cloudwatch_logs {
+      status = "ENABLED"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = "ci/buildspec_${var.repo.branch}_partners.yml"
+  }
+
+  build_timeout = "120"
+}

--- a/app-codepipeline/build_public.tf
+++ b/app-codepipeline/build_public.tf
@@ -1,0 +1,36 @@
+resource "aws_codebuild_project" "public" {
+  name         = "${var.name_prefix}-codebuild-public"
+  service_role = aws_iam_role.codebuild_role.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:6.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    dynamic "environment_variable" {
+      for_each = local.build_env_vars
+      content {
+        name  = environment_variable.value["name"]
+        value = environment_variable.value["value"]
+      }
+    }
+  }
+  logs_config {
+    cloudwatch_logs {
+      status = "ENABLED"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = "ci/buildspec_${var.repo.branch}_public.yml"
+  }
+
+  build_timeout = "120"
+}


### PR DESCRIPTION
This was tested using the `doorway-drumsound-codepipeline` in AWS, using the branch named `test-parallel-build`. This is designed to be merged and applied before merging https://github.com/metrotranscom/doorway/pull/97