### PR TITLE
fix: update bucket names with name_prefix

### DIFF
--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -30,10 +30,10 @@ data "aws_elb_service_account" "current" {}
 locals {
   # We may want to rearrange the order of these in the future based on how easy
   # or hard it is to read at a glance in the console.
-  name_prefix = "${var.name_prefix}-${terraform.workspace}"
+  qualified_name_prefix = "${var.name_prefix}-${terraform.workspace}"
 
   # Alias the old name so it can be removed later
-  default_name = local.name_prefix
+  default_name = local.qualified_name_prefix
 
   default_tags = {
     Team        = var.team_name

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -30,7 +30,10 @@ data "aws_elb_service_account" "current" {}
 locals {
   # We may want to rearrange the order of these in the future based on how easy
   # or hard it is to read at a glance in the console.
-  default_name = "${var.name_prefix}-${terraform.workspace}"
+  name_prefix = "${var.name_prefix}-${terraform.workspace}"
+
+  # Alias the old name so it can be removed later
+  default_name = local.name_prefix
 
   default_tags = {
     Team        = var.team_name

--- a/bloom-instance/s3.tf
+++ b/bloom-instance/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "public_uploads" {
-  bucket_prefix = "${local.name_prefix}-public-uploads"
+  bucket_prefix = "${local.qualified_name_prefix}-public-uploads"
 }
 
 resource "aws_s3_bucket" "secure_uploads" {
-  bucket_prefix = "${local.name_prefix}-secure-uploads"
+  bucket_prefix = "${local.qualified_name_prefix}-secure-uploads"
 }
 
 resource "aws_s3_bucket" "static_content" {
-  bucket_prefix = "${local.name_prefix}-static-content"
+  bucket_prefix = "${local.qualified_name_prefix}-static-content"
 }
 
 resource "aws_s3_bucket_public_access_block" "public_uploads" {

--- a/bloom-instance/s3.tf
+++ b/bloom-instance/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "public_uploads" {
-  bucket_prefix = "${var.name_prefix}-public-uploads"
+  bucket_prefix = "${local.name_prefix}-public-uploads"
 }
 
 resource "aws_s3_bucket" "secure_uploads" {
-  bucket_prefix = "${var.name_prefix}-secure-uploads"
+  bucket_prefix = "${local.name_prefix}-secure-uploads"
 }
 
 resource "aws_s3_bucket" "static_content" {
-  bucket_prefix = "${var.name_prefix}-static-content"
+  bucket_prefix = "${local.name_prefix}-static-content"
 }
 
 resource "aws_s3_bucket_public_access_block" "public_uploads" {


### PR DESCRIPTION
This PR updates the names of the S3 buckets to include both the project ID and the workspace.  Before, all buckets had a name like `doorway-public-uploads...` regardless of whether they were in dev or a personal workspace.  This is intended to make it easier to tell them apart.