### PR TITLE
feat: add migration task

### DIFF
--- a/bloom-instance/ecs/task/ecs.tf
+++ b/bloom-instance/ecs/task/ecs.tf
@@ -31,6 +31,13 @@ resource "aws_ecs_task_definition" "task" {
 
       environment = [for n, val in local.env_vars : { name = n, value = val }]
 
+      secrets = [
+        for n, val in local.secrets : {
+          name      = n,
+          valueFrom = "${val.arn}:${val.key}:${val.version_stage}:${val.version_id}"
+        }
+      ]
+
       logConfiguration = {
         logDriver = "awslogs"
         options = {

--- a/bloom-instance/ecs/task/iam.tf
+++ b/bloom-instance/ecs/task/iam.tf
@@ -98,3 +98,36 @@ resource "aws_iam_role_policy_attachment" "ecr_read" {
   role       = aws_iam_role.task_exec.name
   policy_arn = aws_iam_policy.ecr_read[0].arn
 }
+
+resource "aws_iam_policy" "read_secrets" {
+  count = local.has_secrets ? 1 : 0
+
+  name        = "${local.default_name}-read-secrets"
+  description = "Read secrets needed by task ${local.default_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowReadSecrets"
+        Effect = "Allow"
+
+        Action = [
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ]
+
+        Resource = local.unique_secret_arns
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "read_secrets" {
+  count = local.has_secrets ? 1 : 0
+
+  role       = aws_iam_role.task_exec.name
+  policy_arn = aws_iam_policy.read_secrets[0].arn
+}

--- a/bloom-instance/ecs/task/inputs.tf
+++ b/bloom-instance/ecs/task/inputs.tf
@@ -27,7 +27,14 @@ variable "task" {
     port = optional(number, 80)
 
     # Environment variables to pass to the running containers
-    env_vars = map(string)
+    env_vars = optional(map(string), {})
+
+    secrets = optional(map(object({
+      arn           = string
+      key           = optional(string, "")
+      version_stage = optional(string, "")
+      version_id    = optional(string, "")
+    })), {})
   })
 
   validation {
@@ -51,6 +58,11 @@ variable "task" {
     condition     = var.task.port > 0 && var.task.port <= 65535
     error_message = "port must be a number in the range 1-65535"
   }
+
+  # validation {
+  #   condition     = var.task. > 0 && var.task.port <= 65535
+  #   error_message = "port must be a number in the range 1-65535"
+  # }
 
   description = "An object containing information about the task"
 }

--- a/bloom-instance/ecs/task/inputs.tf
+++ b/bloom-instance/ecs/task/inputs.tf
@@ -59,11 +59,6 @@ variable "task" {
     error_message = "port must be a number in the range 1-65535"
   }
 
-  # validation {
-  #   condition     = var.task. > 0 && var.task.port <= 65535
-  #   error_message = "port must be a number in the range 1-65535"
-  # }
-
   description = "An object containing information about the task"
 }
 

--- a/bloom-instance/ecs/task/locals.tf
+++ b/bloom-instance/ecs/task/locals.tf
@@ -11,6 +11,7 @@ locals {
   image    = var.task.image
   port     = var.task.port
   env_vars = var.task.env_vars
+  secrets  = var.task.secrets
 
   # Check the image name to see if it resides in an ECR repo
   # If so, add permssions for our service to access the repo
@@ -24,4 +25,9 @@ locals {
     region        = data.aws_region.current.name
     stream_prefix = local.name
   }
+
+  # Find all unique secrets arns so we can create permissions to access them
+  unique_secret_arns = distinct([for secret in local.secrets : secret.arn])
+
+  has_secrets = length(local.secrets) > 0
 }

--- a/bloom-instance/service/backend/inputs.tf
+++ b/bloom-instance/service/backend/inputs.tf
@@ -36,6 +36,7 @@ variable "db" {
 
     connection_string = string
     security_group_id = string
+    secret_arn        = string
   })
 }
 

--- a/bloom-instance/service/backend/inputs.tf
+++ b/bloom-instance/service/backend/inputs.tf
@@ -51,6 +51,17 @@ variable "service_definition" {
   description = "A partner portal service definition object"
 }
 
+variable "migration" {
+  # See ecs/task/inputs.tf for type structure
+  type = object({
+    cpu   = number
+    ram   = number
+    image = string
+  })
+
+  description = "A partial representation of the task definition for running migration jobs"
+}
+
 variable "additional_tags" {
   type        = map(string)
   default     = null

--- a/bloom-instance/service/backend/locals.tf
+++ b/bloom-instance/service/backend/locals.tf
@@ -20,32 +20,36 @@ locals {
       PARTNERS_PORTAL_URL = var.partners_portal_url
 
       # Temporary until support for secrets is added
-      DATABASE_URL = var.db.connection_string
+      #DATABASE_URL = var.db.connection_string
 
-      # Temporary for fetching from Bloom backend
-      BLOOM_API_BASE       = "https://hba-dev-proxy.herokuapp.com"
-      BLOOM_LISTINGS_QUERY = "/listings"
-
-      # Temporary
+      # Required to start the server, but not used
       EMAIL_API_KEY     = "SG.<dummy-value>"
       APP_SECRET        = "<dummy-value-that-is-at-least-16-character-long>"
       CLOUDINARY_SECRET = "<dummy-value>"
       CLOUDINARY_KEY    = "<dummy-value>"
 
       # For running migration tasks
-      PGHOST     = var.db.host
-      PGPORT     = var.db.port
-      PGDATABASE = var.db.db_name
-      PGUSER     = var.db.username
-      PGPASSWORD = var.db.password
+      #PGHOST     = var.db.host
+      #PGPORT     = var.db.port
+      #PGDATABASE = var.db.db_name
+      #PGUSER     = var.db.username
+      #PGPASSWORD = var.db.password
     })
   )
+
+  secrets = {
+    DATABASE_URL = {
+      arn = var.db.secret_arn
+      key = "uri"
+    }
+  }
 
   # Set modified env_vars on task object
   task = merge(
     local.base_task,
     {
       env_vars = local.env_vars
+      secrets  = local.secrets
     }
   )
 }

--- a/bloom-instance/service/backend/locals.tf
+++ b/bloom-instance/service/backend/locals.tf
@@ -19,21 +19,15 @@ locals {
       PARTNERS_BASE_URL   = var.partners_portal_url
       PARTNERS_PORTAL_URL = var.partners_portal_url
 
-      # Temporary until support for secrets is added
-      #DATABASE_URL = var.db.connection_string
-
       # Required to start the server, but not used
       EMAIL_API_KEY     = "SG.<dummy-value>"
       APP_SECRET        = "<dummy-value-that-is-at-least-16-character-long>"
       CLOUDINARY_SECRET = "<dummy-value>"
       CLOUDINARY_KEY    = "<dummy-value>"
 
-      # For running migration tasks
-      #PGHOST     = var.db.host
-      #PGPORT     = var.db.port
-      #PGDATABASE = var.db.db_name
-      #PGUSER     = var.db.username
-      #PGPASSWORD = var.db.password
+      # Disable color in log output
+      # Makes logs more readable in CloudWatch
+      NO_COLOR = "true"
     })
   )
 

--- a/bloom-instance/service/backend/migration.tf
+++ b/bloom-instance/service/backend/migration.tf
@@ -1,0 +1,41 @@
+
+module "task" {
+  source = "../../ecs/task"
+
+  name_prefix = var.name_prefix
+  # The migration job needs the same permissions as the main service
+  task_role_arn = aws_iam_role.service.arn
+
+  task = {
+    name  = "${local.name}-migration"
+    cpu   = var.migration.cpu
+    ram   = var.migration.ram
+    image = var.migration.image
+
+    # The migration job requires the other env vars for startup, even if it doesn't use them
+    env_vars = merge(
+      local.env_vars,
+      // But it also needs some extra vars for calling psql
+      {
+        PGHOST     = var.db.host
+        PGPORT     = var.db.port
+        PGDATABASE = var.db.db_name
+        PGUSER     = var.db.username
+      }
+    )
+
+    # It needs DATABASE_URL for seeding
+    secrets = merge(
+      local.secrets,
+      # But it also needs the DB password for psql
+      {
+        PGPASSWORD = {
+          arn = var.db.secret_arn
+          key = "password"
+        }
+      }
+    )
+  }
+
+  additional_tags = var.additional_tags
+}

--- a/bloom-instance/services.tf
+++ b/bloom-instance/services.tf
@@ -54,6 +54,8 @@ module "backend_api" {
   subnet_map = module.network.subnets
   db         = module.db
 
+  migration = var.backend_api.migration
+
   partners_portal_url = "https://partners.demo.doorway.housingbayarea.org/" # Placeholder
 
   additional_tags = {

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -248,6 +248,12 @@ backend_api = {
     }
   }
 
+  migration = {
+    cpu   = 256
+    ram   = 1024
+    image = "<repo>/backend:migrate"
+  }
+
   service = {
     subnet_group = "app"
 


### PR DESCRIPTION
Adds a task definition for running db migration commands.  It's a huge pain in the butt to do it manually when setting up a new environment, so this should help a little bit.  Could also be invoked from pipeline with minimal configuration since all env vars are pre-populated in the task definition.

This is based off the secrets branch since it relies on it, but it shouldn't matter since that one already got merged in.