### PR TITLE
fix: replace hardcoded urls with generated values

### DIFF
--- a/bloom-instance/alb/listener/outputs.tf
+++ b/bloom-instance/alb/listener/outputs.tf
@@ -2,3 +2,11 @@
 output "arn" {
   value = aws_lb_listener.listener.arn
 }
+
+output "port" {
+  value = local.port
+}
+
+output "is_secure" {
+  value = local.use_tls
+}

--- a/bloom-instance/ecs/service/inputs.tf
+++ b/bloom-instance/ecs/service/inputs.tf
@@ -17,6 +17,7 @@ variable "task_arn" {
 variable "alb_map" {
   type = map(object({
     arn = string
+    dns_name = string
     listeners = map(object({
       arn       = string
       port      = number

--- a/bloom-instance/ecs/service/inputs.tf
+++ b/bloom-instance/ecs/service/inputs.tf
@@ -16,7 +16,7 @@ variable "task_arn" {
 
 variable "alb_map" {
   type = map(object({
-    arn = string
+    arn      = string
     dns_name = string
     listeners = map(object({
       arn       = string
@@ -50,7 +50,8 @@ variable "service" {
     # This object tells the service which ALB listeners to add forwarding rules for
     albs = map(object({
       listeners = map(object({
-        domains = list(string)
+        listen_on_alb_dns_name = optional(bool, false)
+        domains                = list(string)
       }))
     }))
 

--- a/bloom-instance/ecs/service/inputs.tf
+++ b/bloom-instance/ecs/service/inputs.tf
@@ -18,7 +18,9 @@ variable "alb_map" {
   type = map(object({
     arn = string
     listeners = map(object({
-      arn = string
+      arn       = string
+      port      = number
+      is_secure = bool
     }))
     security_group = object({
       id = string

--- a/bloom-instance/ecs/service/locals.tf
+++ b/bloom-instance/ecs/service/locals.tf
@@ -41,6 +41,11 @@ locals {
     ]
   } }
 
+  # Collapse all URLs into a single list
+  url_list = flatten([for alb_name, by_listener in local.urls_by_listener : [
+    for urls in by_listener : urls
+  ]])
+
   security_group_ids = toset([for alb in local.filtered_albs : alb.security_group.id])
 
   subnet_ids = [for subnet in var.subnet_map[var.service.subnet_group] : subnet.id]

--- a/bloom-instance/ecs/service/locals.tf
+++ b/bloom-instance/ecs/service/locals.tf
@@ -21,22 +21,33 @@ locals {
 
   filtered_albs = { for alb_name, alb in var.alb_map : alb_name => alb if try(local.requested_albs[alb_name] != null, false) }
 
+  domains_by_listener = { for alb_name, alb in local.requested_albs : alb_name => {
+    for listener_name, listener in alb.listeners :
+    listener_name => listener.listen_on_alb_dns_name ?
+    concat(listener.domains, [var.alb_map[alb_name].dns_name]) :
+    listener.domains
+  } }
+
   rule_map = merge([for alb_name, alb in local.requested_albs : {
     for listener_name, listener in alb.listeners : "${alb_name}-${listener_name}" => {
       arn     = var.alb_map[alb_name].listeners[listener_name].arn
-      domains = listener.domains
+      domains = local.domains_by_listener[alb_name][listener_name]
     }
   }]...)
 
   # Generate URLs that can be used to access this service
-  urls_by_listener = { for alb_name, alb in local.requested_albs : alb_name => {
-    for listener_name, listener in alb.listeners : listener_name => [
-      for domain in listener.domains : join("", [
+  urls_by_listener = { for alb_name, alb in local.filtered_albs : alb_name => {
+    for listener_name, listener in local.requested_albs[alb_name].listeners : listener_name => [
+      for domain in local.domains_by_listener[alb_name][listener_name] : join("", [
         # We need to look up info about the listener to determine how to put together our URL
-        var.alb_map[alb_name].listeners[listener_name].is_secure ? "https" : "http",
+        alb.listeners[listener_name].is_secure ? "https" : "http",
         "://",
         domain,
-        ":${var.alb_map[alb_name].listeners[listener_name].port}"
+        # Add the port if non-standard
+        (alb.listeners[listener_name].port == 443 &&
+        alb.listeners[listener_name].is_secure) ||
+        alb.listeners[listener_name].port == 80
+        ? "" : ":${alb.listeners[listener_name].port}"
       ])
     ]
   } }

--- a/bloom-instance/ecs/service/locals.tf
+++ b/bloom-instance/ecs/service/locals.tf
@@ -31,7 +31,8 @@ locals {
   # Generate URLs that can be used to access this service
   urls_by_listener = { for alb_name, alb in local.requested_albs : alb_name => {
     for listener_name, listener in alb.listeners : listener_name => [
-      for domain in listener.domains : join("", [
+      # Add ALB DNS name to list of domains and format them into URLs
+      for domain in concat(listener.domains, [var.alb_map[alb_name].dns_name]) : join("", [
         # We need to look up info about the listener to determine how to put together our URL
         var.alb_map[alb_name].listeners[listener_name].is_secure ? "https" : "http",
         "://",

--- a/bloom-instance/ecs/service/locals.tf
+++ b/bloom-instance/ecs/service/locals.tf
@@ -31,8 +31,7 @@ locals {
   # Generate URLs that can be used to access this service
   urls_by_listener = { for alb_name, alb in local.requested_albs : alb_name => {
     for listener_name, listener in alb.listeners : listener_name => [
-      # Add ALB DNS name to list of domains and format them into URLs
-      for domain in concat(listener.domains, [var.alb_map[alb_name].dns_name]) : join("", [
+      for domain in listener.domains : join("", [
         # We need to look up info about the listener to determine how to put together our URL
         var.alb_map[alb_name].listeners[listener_name].is_secure ? "https" : "http",
         "://",

--- a/bloom-instance/ecs/service/outputs.tf
+++ b/bloom-instance/ecs/service/outputs.tf
@@ -7,6 +7,10 @@ output "security_group" {
   value = aws_security_group.service
 }
 
+output "urls_by_listener" {
+  value = local.urls_by_listener
+}
+
 /*
 output "public_url" {
   value = ""

--- a/bloom-instance/ecs/service/outputs.tf
+++ b/bloom-instance/ecs/service/outputs.tf
@@ -11,6 +11,10 @@ output "urls_by_listener" {
   value = local.urls_by_listener
 }
 
+output "url_list" {
+  value = local.url_list
+}
+
 /*
 output "public_url" {
   value = ""

--- a/bloom-instance/outputs.tf
+++ b/bloom-instance/outputs.tf
@@ -2,3 +2,11 @@
 output "cert_validation_records_not_created" {
   value = { for key, cert in module.certs : key => cert.unmatched_validation_records }
 }
+
+output "partner_site_urls" {
+  value = module.partner_site.urls_by_listener
+}
+
+output "backend_api_urls" {
+  value = module.backend_api.urls_by_listener
+}

--- a/bloom-instance/outputs.tf
+++ b/bloom-instance/outputs.tf
@@ -3,6 +3,10 @@ output "cert_validation_records_not_created" {
   value = { for key, cert in module.certs : key => cert.unmatched_validation_records }
 }
 
+output "public_site_urls" {
+  value = [for site in module.public_sites : site.urls_by_listener]
+}
+
 output "partner_site_urls" {
   value = module.partner_site.urls_by_listener
 }

--- a/bloom-instance/outputs.tf
+++ b/bloom-instance/outputs.tf
@@ -3,14 +3,10 @@ output "cert_validation_records_not_created" {
   value = { for key, cert in module.certs : key => cert.unmatched_validation_records }
 }
 
-output "public_site_urls" {
-  value = [for site in module.public_sites : site.urls_by_listener]
-}
-
-output "partner_site_urls" {
-  value = module.partner_site.urls_by_listener
-}
-
-output "backend_api_urls" {
-  value = module.backend_api.urls_by_listener
+output "urls" {
+  value = {
+    public   = [for site in module.public_sites : site.url_list]
+    partners = module.partner_site.url_list
+    backend  = module.backend_api.url_list
+  }
 }

--- a/bloom-instance/service/backend/inputs.tf
+++ b/bloom-instance/service/backend/inputs.tf
@@ -26,6 +26,15 @@ variable "subnet_map" {
   description = "A map of available subnets"
 }
 
+variable "internal_url_path" {
+  type = tuple([
+    string, # ALB name
+    string, # listener name
+    number  # index of domain/url
+  ])
+  description = "Which URL to provide to other services in the format [alb_name, listener_name, url_index]"
+}
+
 variable "partners_portal_url" {
   type        = string
   description = "The URL to the partners portal, for injecting into email templates"

--- a/bloom-instance/service/backend/locals.tf
+++ b/bloom-instance/service/backend/locals.tf
@@ -46,4 +46,12 @@ locals {
       secrets  = local.secrets
     }
   )
+
+  # Find which URL to provide to other services
+  urls_by_listener  = module.service.urls_by_listener
+  internal_alb      = var.internal_url_path[0]
+  internal_listener = var.internal_url_path[1]
+  internal_url_pos  = var.internal_url_path[2]
+
+  internal_url = local.urls_by_listener[local.internal_alb][local.internal_listener][local.internal_url_pos]
 }

--- a/bloom-instance/service/backend/outputs.tf
+++ b/bloom-instance/service/backend/outputs.tf
@@ -7,6 +7,6 @@ output "security_group" {
   value = module.service.security_group
 }
 
-output "urls_by_listener" {
-  value = module.service.urls_by_listener
+output "url_list" {
+  value = module.service.url_list
 }

--- a/bloom-instance/service/backend/outputs.tf
+++ b/bloom-instance/service/backend/outputs.tf
@@ -6,3 +6,7 @@ output "target_group" {
 output "security_group" {
   value = module.service.security_group
 }
+
+output "urls_by_listener" {
+  value = module.service.urls_by_listener
+}

--- a/bloom-instance/service/backend/outputs.tf
+++ b/bloom-instance/service/backend/outputs.tf
@@ -10,3 +10,7 @@ output "security_group" {
 output "url_list" {
   value = module.service.url_list
 }
+
+output "internal_url" {
+  value = local.internal_url
+}

--- a/bloom-instance/service/inputs.tf
+++ b/bloom-instance/service/inputs.tf
@@ -30,7 +30,8 @@ variable "log_group_name" {
 
 variable "alb_map" {
   type = map(object({
-    arn = string
+    arn      = string
+    dns_name = string
     security_group = object({
       id = string
     })

--- a/bloom-instance/service/inputs.tf
+++ b/bloom-instance/service/inputs.tf
@@ -35,7 +35,9 @@ variable "alb_map" {
       id = string
     })
     listeners = map(object({
-      arn = string
+      arn       = string
+      port      = number
+      is_secure = bool
     }))
   }))
 

--- a/bloom-instance/service/outputs.tf
+++ b/bloom-instance/service/outputs.tf
@@ -10,3 +10,7 @@ output "security_group" {
 output "urls_by_listener" {
   value = module.service.urls_by_listener
 }
+
+output "url_list" {
+  value = module.service.url_list
+}

--- a/bloom-instance/service/outputs.tf
+++ b/bloom-instance/service/outputs.tf
@@ -6,3 +6,7 @@ output "target_group" {
 output "security_group" {
   value = module.service.security_group
 }
+
+output "urls_by_listener" {
+  value = module.service.urls_by_listener
+}

--- a/bloom-instance/service/partner-site/outputs.tf
+++ b/bloom-instance/service/partner-site/outputs.tf
@@ -7,6 +7,6 @@ output "security_group" {
   value = module.service.security_group
 }
 
-output "urls_by_listener" {
-  value = module.service.urls_by_listener
+output "url_list" {
+  value = module.service.url_list
 }

--- a/bloom-instance/service/partner-site/outputs.tf
+++ b/bloom-instance/service/partner-site/outputs.tf
@@ -6,3 +6,7 @@ output "target_group" {
 output "security_group" {
   value = module.service.security_group
 }
+
+output "urls_by_listener" {
+  value = module.service.urls_by_listener
+}

--- a/bloom-instance/service/public-site/outputs.tf
+++ b/bloom-instance/service/public-site/outputs.tf
@@ -7,6 +7,6 @@ output "security_group" {
   value = module.service.security_group
 }
 
-output "urls_by_listener" {
-  value = module.service.urls_by_listener
+output "url_list" {
+  value = module.service.url_list
 }

--- a/bloom-instance/service/public-site/outputs.tf
+++ b/bloom-instance/service/public-site/outputs.tf
@@ -6,3 +6,7 @@ output "target_group" {
 output "security_group" {
   value = module.service.security_group
 }
+
+output "urls_by_listener" {
+  value = module.service.urls_by_listener
+}

--- a/bloom-instance/services.tf
+++ b/bloom-instance/services.tf
@@ -15,7 +15,7 @@ module "public_sites" {
   secure_upload_bucket = aws_s3_bucket.secure_uploads.bucket
 
   # Just a placeholder for now
-  backend_api_base = ""
+  backend_api_base = module.backend_api.internal_url
 
   additional_tags = {
     ServiceType = "public-site"
@@ -38,7 +38,7 @@ module "partner_site" {
   secure_upload_bucket = aws_s3_bucket.secure_uploads.bucket
 
   # Just a placeholder for now
-  backend_api_base = ""
+  backend_api_base = module.backend_api.internal_url
 
   additional_tags = {
     ServiceType = "partner-site"
@@ -60,6 +60,8 @@ module "backend_api" {
   migration = var.backend_api.migration
 
   partners_portal_url = "" # Placeholder
+
+  internal_url_path = var.backend_api.internal_url_path
 
   additional_tags = {
     ServiceType = "backend-api"

--- a/bloom-instance/services.tf
+++ b/bloom-instance/services.tf
@@ -59,7 +59,7 @@ module "backend_api" {
 
   migration = var.backend_api.migration
 
-  partners_portal_url = "" # Placeholder
+  partners_portal_url = var.backend_api.partners_portal_url
 
   internal_url_path = var.backend_api.internal_url_path
 

--- a/bloom-instance/services.tf
+++ b/bloom-instance/services.tf
@@ -15,7 +15,7 @@ module "public_sites" {
   secure_upload_bucket = aws_s3_bucket.secure_uploads.bucket
 
   # Just a placeholder for now
-  backend_api_base = "http://localhost:3100"
+  backend_api_base = ""
 
   additional_tags = {
     ServiceType = "public-site"
@@ -38,7 +38,7 @@ module "partner_site" {
   secure_upload_bucket = aws_s3_bucket.secure_uploads.bucket
 
   # Just a placeholder for now
-  backend_api_base = "http://localhost:3100"
+  backend_api_base = ""
 
   additional_tags = {
     ServiceType = "partner-site"
@@ -59,7 +59,7 @@ module "backend_api" {
 
   migration = var.backend_api.migration
 
-  partners_portal_url = "https://partners.demo.doorway.housingbayarea.org/" # Placeholder
+  partners_portal_url = "" # Placeholder
 
   additional_tags = {
     ServiceType = "backend-api"


### PR DESCRIPTION
Each of the services needs to know where to find at least one of the others.  This was previously hardcoded, but needs to be replaced with something more flexible.  This PR, in conjunction with [the corresponding config PR](https://github.com/metrotranscom/doorway-config/pull/16), adds the ability to specify which URLs to provide in the form of two extra properties attached to the root `backend_api` var.

In addition, it also adds some functionality for exporting URLs from services so they can be passed directly even if they were unknown prior to deployment.

[plan.txt](https://github.com/metrotranscom/doorway-infra/files/11556669/plan.txt)
