### PR TITLE
fix: typo in scheduler role name

### DIFF
--- a/bloom-instance/cronjob/iam.tf
+++ b/bloom-instance/cronjob/iam.tf
@@ -1,6 +1,6 @@
 
 resource "aws_iam_role" "scheduler_exec" {
-  name = "${local.qualified_name_prefix}-schecduler-exec"
+  name = "${local.qualified_name_prefix}-scheduler-exec"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
There was a typo in the name generated for the scheduler exec role in the cronjob module.  This corrects it