### PR TITLE
fix: remove password from db outputs

### DIFF
--- a/bloom-instance/db/outputs.tf
+++ b/bloom-instance/db/outputs.tf
@@ -23,11 +23,6 @@ output "security_group_id" {
   value = aws_security_group.db.id
 }
 
-# These two are temporary until support for secrets is added to tasks 
-output "password" {
-  value = local.password
-}
-
 output "connection_string" {
   value = local.conn_string
 }

--- a/bloom-instance/service/backend/inputs.tf
+++ b/bloom-instance/service/backend/inputs.tf
@@ -46,7 +46,6 @@ variable "db" {
     port     = number
     username = string
     db_name  = string
-    password = string
 
     connection_string = string
     security_group_id = string


### PR DESCRIPTION
Now that the DB password is stored in a secret, we don't need to output it from the db module.  This has no change on the deployment