### PR TITLE
feat: add pipeline notifications

### DIFF
--- a/infra-pipeline/main.tf
+++ b/infra-pipeline/main.tf
@@ -38,7 +38,9 @@ module "pipeline" {
   name_prefix             = "${local.qualified_name_prefix}-bloom-infra-pipeline"
   codestar_connection_arn = local.codestar_connection_arn
 
-  tf_root      = var.pipeline.tf_root
-  sources      = var.pipeline.sources
-  environments = var.pipeline.environments
+  tf_root             = var.pipeline.tf_root
+  sources             = var.pipeline.sources
+  environments        = var.pipeline.environments
+  notification_topics = var.pipeline.notification_topics
+  notification_rules  = var.pipeline.notify
 }

--- a/infra-pipeline/main.tf
+++ b/infra-pipeline/main.tf
@@ -27,6 +27,7 @@ locals {
   default_tags = {
     Owner     = var.owner
     Project   = var.project_name
+    ProjectID = var.project_id
     Workspace = terraform.workspace
   }
 }

--- a/infra-pipeline/main.tf
+++ b/infra-pipeline/main.tf
@@ -34,8 +34,8 @@ locals {
 module "pipeline" {
   source = "./pipeline"
 
-  name                    = "${local.qualified_name_prefix}-bloom-infra"
-  name_prefix             = "${local.qualified_name_prefix}-bloom-infra-pipeline"
+  name                    = var.pipeline.name
+  name_prefix             = local.qualified_name_prefix
   codestar_connection_arn = local.codestar_connection_arn
 
   tf_root             = var.pipeline.tf_root

--- a/infra-pipeline/pipeline/iam.tf
+++ b/infra-pipeline/pipeline/iam.tf
@@ -1,6 +1,6 @@
 
 resource "aws_iam_role" "pipeline" {
-  name = "${var.name_prefix}-exec"
+  name = "${local.qualified_name}-exec"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -18,7 +18,7 @@ resource "aws_iam_role" "pipeline" {
 }
 
 resource "aws_iam_policy" "pipeline" {
-  name = "${var.name_prefix}-pipeline"
+  name = "${local.qualified_name}-pipeline"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -63,7 +63,7 @@ resource "aws_iam_policy" "pipeline" {
 
 resource "aws_iam_policy" "approvals" {
   count = local.have_approvals ? 1 : 0
-  name  = "${var.name_prefix}-approvals"
+  name  = "${local.qualified_name}-approvals"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy_attachment" "approvals" {
 }
 
 resource "aws_iam_policy" "codebuild_artifacts" {
-  name = "${var.name_prefix}-codebuild-artifacts"
+  name = "${local.qualified_name}-artifacts"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/infra-pipeline/pipeline/iam.tf
+++ b/infra-pipeline/pipeline/iam.tf
@@ -62,7 +62,7 @@ resource "aws_iam_policy" "pipeline" {
 }
 
 resource "aws_iam_policy" "approvals" {
-  count = length(local.notification_topic_arns) > 0 ? 1 : 0
+  count = local.have_approvals ? 1 : 0
   name  = "${var.name_prefix}-approvals"
 
   policy = jsonencode({
@@ -76,7 +76,7 @@ resource "aws_iam_policy" "approvals" {
           "sns:Publish"
         ]
 
-        Resource = local.notification_topic_arns
+        Resource = local.approval_topic_arn_list
       },
     ],
   })
@@ -88,7 +88,7 @@ resource "aws_iam_role_policy_attachment" "pipeline" {
 }
 
 resource "aws_iam_role_policy_attachment" "approvals" {
-  count      = length(local.notification_topic_arns) > 0 ? 1 : 0
+  count      = local.have_approvals ? 1 : 0
   role       = aws_iam_role.pipeline.name
   policy_arn = aws_iam_policy.approvals[0].arn
 }

--- a/infra-pipeline/pipeline/inputs.tf
+++ b/infra-pipeline/pipeline/inputs.tf
@@ -104,11 +104,11 @@ variable "environments" {
 
     # Whether this stage requires approval prior to deployment
     approval = optional(object({
-      required  = optional(bool, true)
-      approvers = set(string)
+      required = optional(bool, true)
+      topic    = string
       }), {
-      required  = false
-      approvers = []
+      required = false
+      topic    = ""
     })
   }))
   description = "The environments to deploy infra into"

--- a/infra-pipeline/pipeline/inputs.tf
+++ b/infra-pipeline/pipeline/inputs.tf
@@ -49,6 +49,25 @@ variable "tf_root" {
   description = "The location (source repo and path) to run terraform commands"
 }
 
+variable "notification_topics" {
+  type = map(object({
+    emails = set(string)
+  }))
+
+  description = "Named groups of people to notify when a certain event occurs"
+}
+
+variable "notification_rules" {
+  type = list(object({
+    # Which topic to send notifications to 
+    topic  = string
+    detail = optional(string, "BASIC")
+    on     = map(set(string))
+  }))
+
+  description = "Rules for triggering notifications on pipeline events"
+}
+
 variable "environments" {
   type = list(object({
     # The name of this environment

--- a/infra-pipeline/pipeline/main.tf
+++ b/infra-pipeline/pipeline/main.tf
@@ -140,7 +140,7 @@ module "notification_rules" {
 }
 
 resource "aws_codepipeline" "pipeline" {
-  name     = var.name
+  name     = local.qualified_name
   role_arn = aws_iam_role.pipeline.arn
 
   artifact_store {

--- a/infra-pipeline/pipeline/notification/rule/inputs.tf
+++ b/infra-pipeline/pipeline/notification/rule/inputs.tf
@@ -1,0 +1,36 @@
+
+variable "name_prefix" {
+  type        = string
+  description = "A prefix to enable resource namespacing"
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the environment for this approval"
+}
+
+variable "topic_arn" {
+  type        = string
+  description = "The SNS topic ARN to send notifications to"
+}
+
+variable "resource_arn" {
+  type        = string
+  description = "The ARN of the CodePipeline to watch"
+}
+
+variable "detail" {
+  type        = string
+  default     = "BASIC"
+  description = "The level of detail to include in the notification"
+
+  validation {
+    condition     = contains(["BASIC", "FULL"], var.detail)
+    error_message = "Valid values for var.detail are (BASIC, FULL)"
+  }
+}
+
+variable "events" {
+  type        = set(string)
+  description = "The event type to alert on"
+}

--- a/infra-pipeline/pipeline/notification/rule/main.tf
+++ b/infra-pipeline/pipeline/notification/rule/main.tf
@@ -1,0 +1,11 @@
+resource "aws_codestarnotifications_notification_rule" "rule" {
+  detail_type    = var.detail
+  event_type_ids = var.events
+
+  name     = "${var.name_prefix}-notify-${var.name}"
+  resource = var.resource_arn
+
+  target {
+    address = var.topic_arn
+  }
+}

--- a/infra-pipeline/pipeline/notification/rule/pipeline/inputs.tf
+++ b/infra-pipeline/pipeline/notification/rule/pipeline/inputs.tf
@@ -1,0 +1,35 @@
+
+variable "name_prefix" {
+  type        = string
+  description = "A prefix to enable resource namespacing"
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the environment for this approval"
+}
+
+variable "topic_arn" {
+  type        = string
+  description = "The SNS topic ARN to send notifications to"
+}
+
+variable "pipeline_arn" {
+  type        = string
+  description = "The ARN of the CodePipeline to watch"
+}
+
+variable "detail" {
+  type        = string
+  description = "The level of detail to include in the notification"
+}
+
+variable "events" {
+  type = object({
+    action   = optional(set(string), [])
+    stage    = optional(set(string), [])
+    pipeline = optional(set(string), [])
+    approval = optional(set(string), [])
+  })
+  description = "The event type to alert on"
+}

--- a/infra-pipeline/pipeline/notification/rule/pipeline/main.tf
+++ b/infra-pipeline/pipeline/notification/rule/pipeline/main.tf
@@ -1,0 +1,49 @@
+
+locals {
+  event_maps = {
+    action : {
+      succeeded : "codepipeline-pipeline-action-execution-succeeded"
+      failed : "codepipeline-pipeline-action-execution-failed"
+      canceled : "codepipeline-pipeline-action-execution-canceled"
+      started : "codepipeline-pipeline-action-execution-started"
+    }
+
+    stage : {
+      succeeded : "codepipeline-pipeline-stage-execution-succeeded"
+      failed : "codepipeline-pipeline-stage-execution-failed"
+      canceled : "codepipeline-pipeline-stage-execution-canceled"
+      started : "codepipeline-pipeline-stage-execution-started"
+      resumed : "codepipeline-pipeline-stage-execution-resumed"
+    }
+
+    pipeline : {
+      succeeded : "codepipeline-pipeline-pipeline-execution-succeeded"
+      failed : "codepipeline-pipeline-pipeline-execution-failed"
+      canceled : "codepipeline-pipeline-pipeline-execution-canceled"
+      started : "codepipeline-pipeline-pipeline-execution-started"
+      resumed : "codepipeline-pipeline-pipeline-execution-resumed"
+      superseded : "codepipeline-pipeline-pipeline-execution-superseded"
+    }
+
+    approval : {
+      succeeded : "codepipeline-pipeline-manual-approval-succeeded"
+      failed : "codepipeline-pipeline-manual-approval-failed"
+      needed : "codepipeline-pipeline-manual-approval-needed"
+    }
+  }
+
+  events = concat([for scope, events in var.events : [
+    for event in events : local.event_maps[scope][event]
+  ]]...)
+}
+
+module "rule" {
+  source = "../"
+
+  name_prefix  = var.name_prefix
+  name         = var.name
+  topic_arn    = var.topic_arn
+  resource_arn = var.pipeline_arn
+  detail       = var.detail
+  events       = local.events
+}

--- a/infra-pipeline/pipeline/notification/topic/inputs.tf
+++ b/infra-pipeline/pipeline/notification/topic/inputs.tf
@@ -1,0 +1,15 @@
+
+variable "name_prefix" {
+  type        = string
+  description = "A prefix to enable resource namespacing"
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the environment for this approval"
+}
+
+variable "emails" {
+  type        = set(string)
+  description = "The email addresses to send notifications to"
+}

--- a/infra-pipeline/pipeline/notification/topic/main.tf
+++ b/infra-pipeline/pipeline/notification/topic/main.tf
@@ -1,0 +1,28 @@
+
+resource "aws_sns_topic" "topic" {
+  name = "${var.name_prefix}-notify-${var.name}"
+}
+
+resource "aws_sns_topic_subscription" "emails" {
+  for_each  = var.emails
+  topic_arn = aws_sns_topic.topic.arn
+  protocol  = "email"
+  endpoint  = each.value
+}
+
+resource "aws_sns_topic_policy" "allow_codestar" {
+  arn = aws_sns_topic.topic.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = {
+      Sid    = "AllowCodeStarNotifications"
+      Action = ["sns:Publish"]
+      Effect = "Allow"
+      Principal = {
+        Service = "codestar-notifications.amazonaws.com"
+      }
+      Resource = aws_sns_topic.topic.arn,
+    }
+  })
+}

--- a/infra-pipeline/pipeline/notification/topic/outputs.tf
+++ b/infra-pipeline/pipeline/notification/topic/outputs.tf
@@ -1,0 +1,4 @@
+
+output "topic_arn" {
+  value = aws_sns_topic.topic.arn
+}

--- a/infra-pipeline/tfvars.template
+++ b/infra-pipeline/tfvars.template
@@ -23,6 +23,36 @@ pipeline = {
     }
   }
 
+  notification_topics = {
+    "infra" : {
+      emails : ["admin@example.com"]
+    }
+    "developers" : {
+      emails : ["dev@example.com"]
+    }
+    "approvers" : {
+      emails : ["pm@example.com", "security@example.com"]
+    }
+  }
+
+  notify = [
+    {
+      topic : "infra"
+      on : {
+        pipeline : ["failed"]
+        approval : ["needed", "failed"]
+      }
+    },
+    {
+      topic : "developers"
+      on : {
+        action : ["failed"]
+        stage : ["failed"]
+        pipeline : ["failed"]
+      }
+    }
+  ]
+
   environments = [
     {
       # The name of the environment
@@ -48,6 +78,10 @@ pipeline = {
         env_vars = {
           TF_VERSION : "1.3.7"
         }
+      }
+
+      approval = {
+        topic = "approvers"
       }
 
       # Vars for the apply stage

--- a/infra-pipeline/tfvars.template
+++ b/infra-pipeline/tfvars.template
@@ -5,7 +5,7 @@ owner = "infra_team+setup@your-org.dev"
 codestar_connection_arn = ""
 
 pipeline = {
-  name = "Deploy Bloom Infra"
+  name = "bloom-infra-pipeline"
 
   source = {
     "templates" : {

--- a/infra-pipeline/vars.tf
+++ b/infra-pipeline/vars.tf
@@ -47,6 +47,7 @@ variable "codestar_connection_arn" {
 
 variable "pipeline" {
   type = object({
+    name = string
     # See ./pipeline/inputs.tf for object structures
     tf_root             = any
     sources             = any

--- a/infra-pipeline/vars.tf
+++ b/infra-pipeline/vars.tf
@@ -48,8 +48,10 @@ variable "codestar_connection_arn" {
 variable "pipeline" {
   type = object({
     # See ./pipeline/inputs.tf for object structures
-    tf_root      = any
-    sources      = any
-    environments = any
+    tf_root             = any
+    sources             = any
+    environments        = any
+    notification_topics = any
+    notify              = any
   })
 }


### PR DESCRIPTION
This PR adds support for defining pipeline notifications.  You can create notification topics, automatically subscribe emails to them, and filter which pipeline events trigger the notifications.  It also makes a few small unrelated changes like adding a name var to the pipeline object and changing the approval config to use the notification topics rather than its own thing.

The tfvar file used for the live deployment is available here: https://github.com/metrotranscom/doorway-config/blob/test/chriscasto/infra-pipeline/chriscasto.tfvars