### PR TITLE
fix: ignore changes to db engine_version

### DIFF
--- a/bloom-instance/db/aurora.tf
+++ b/bloom-instance/db/aurora.tf
@@ -56,7 +56,11 @@ resource "aws_rds_cluster" "aurora" {
 
   # TLS
 
-
+  # Periodic upgrades will change the running engine version
+  # We don't want future infra updates to roll that back
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }
 
 resource "aws_rds_cluster_instance" "serverless" {

--- a/bloom-instance/db/rds.tf
+++ b/bloom-instance/db/rds.tf
@@ -54,4 +54,10 @@ resource "aws_db_instance" "rds" {
 
   # TLS
   #ca_cert_identifier
+
+  # Periodic upgrades will change the running engine version
+  # We don't want future infra updates to roll that back
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }


### PR DESCRIPTION
AWS will periodically update running RDS instances to update them to a new minor version.  When terraform sees that the `engine_version` is different than what is specified in the tfvars file on the next `plan`/`apply`, it attempts to roll it back to the initially requested version, undoing the upgrades.  This can cause a lot of thrashing as RDS and terraform continue to go back and forth applying and then undoing updates, which is undesirable.

This PR updates the db module to tell terraform to ignore any changes to `engine_version` when trying to determine which changes need to be made.