### PR TITLE
refactor: normalize bloom infra var names

### DIFF
--- a/bloom-instance/alb.tf
+++ b/bloom-instance/alb.tf
@@ -14,7 +14,7 @@ module "albs" {
   # The ARN is then resolved by the listener module based on the tls config
   cert_map = { for name, cert in module.certs : name => cert.arn }
 
-  name_prefix    = local.default_name
+  name_prefix    = local.qualified_name_prefix
   name           = each.key
   enable_logging = each.value.enable_logging
   internal       = each.value.internal

--- a/bloom-instance/cronjobs.tf
+++ b/bloom-instance/cronjobs.tf
@@ -2,7 +2,7 @@
 module "import_listings" {
   source = "./cronjob/import-listings"
 
-  name_prefix     = local.default_name
+  name_prefix     = local.qualified_name_prefix
   ecs_cluster_arn = aws_ecs_cluster.default.arn
   log_group_name  = local.task_log_group_name
 

--- a/bloom-instance/db.tf
+++ b/bloom-instance/db.tf
@@ -1,7 +1,7 @@
 
 module "db" {
   source      = "./db"
-  name_prefix = local.default_name
+  name_prefix = local.qualified_name_prefix
   subnet_map  = module.network.subnets
   settings    = var.database
 }

--- a/bloom-instance/logging.tf
+++ b/bloom-instance/logging.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "logging_bucket" {
-  bucket_prefix = "${var.name_prefix}-logging"
+  bucket_prefix = "${local.project_id}-logging"
 }
 
 resource "aws_s3_bucket_policy" "log_bucket_policy" {

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -35,9 +35,6 @@ locals {
   # or hard it is to read at a glance in the console.
   qualified_name_prefix = "${local.project_id}-${terraform.workspace}"
 
-  # Alias the old name so it can be removed later
-  default_name = local.qualified_name_prefix
-
   default_tags = {
     Team        = var.owner
     Project     = var.project_name
@@ -53,12 +50,12 @@ locals {
   elb_service_account_arn = data.aws_elb_service_account.current.arn
 
   # Defining this here ensures that all of our task logs get grouped together
-  task_log_group_name = "${local.default_name}-tasks"
+  task_log_group_name = "${local.qualified_name_prefix}-tasks"
 }
 
 # The default cluster for all ECS tasks and services
 resource "aws_ecs_cluster" "default" {
-  name = "${local.default_name}-default"
+  name = "${local.qualified_name_prefix}-default"
 }
 
 # inform terraform about renamed network resources

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -39,7 +39,7 @@ locals {
   default_name = local.qualified_name_prefix
 
   default_tags = {
-    Team        = var.team_name
+    Team        = var.owner
     Project     = var.project_name
     Application = var.application_name
     Environment = var.environment

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -39,7 +39,7 @@ locals {
     Team        = var.team_name
     Project     = var.project_name
     Application = var.application_name
-    Environment = var.sdlc_stage
+    Environment = var.environment
     Workspace   = terraform.workspace
   }
 

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -28,9 +28,12 @@ data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "current" {}
 
 locals {
+  # This level of indirection helps when refactoring widely-used vars
+  project_id = var.project_id
+
   # We may want to rearrange the order of these in the future based on how easy
   # or hard it is to read at a glance in the console.
-  qualified_name_prefix = "${var.name_prefix}-${terraform.workspace}"
+  qualified_name_prefix = "${local.project_id}-${terraform.workspace}"
 
   # Alias the old name so it can be removed later
   default_name = local.qualified_name_prefix

--- a/bloom-instance/main.tf
+++ b/bloom-instance/main.tf
@@ -36,8 +36,9 @@ locals {
   qualified_name_prefix = "${local.project_id}-${terraform.workspace}"
 
   default_tags = {
-    Team        = var.owner
+    Owner       = var.owner
     Project     = var.project_name
+    ProjectID   = local.project_id
     Application = var.application_name
     Environment = var.environment
     Workspace   = terraform.workspace

--- a/bloom-instance/network.tf
+++ b/bloom-instance/network.tf
@@ -1,7 +1,7 @@
 module "network" {
   source = "./network"
 
-  name_prefix   = local.default_name
+  name_prefix   = local.qualified_name_prefix
   vpc_cidr      = var.network.vpc_cidr
   subnet_groups = var.network.subnet_groups
 }

--- a/bloom-instance/services.tf
+++ b/bloom-instance/services.tf
@@ -4,7 +4,7 @@ module "public_sites" {
   for_each = { for idx, srv in var.public_sites : idx => srv }
   source   = "./service/public-site"
 
-  name_prefix        = local.default_name
+  name_prefix        = local.qualified_name_prefix
   service_definition = each.value
   log_group_name     = local.task_log_group_name
 
@@ -24,7 +24,7 @@ module "public_sites" {
 module "partner_site" {
   source = "./service/partner-site"
 
-  name_prefix        = local.default_name
+  name_prefix        = local.qualified_name_prefix
   service_definition = var.partner_site
   log_group_name     = local.task_log_group_name
 
@@ -43,7 +43,7 @@ module "partner_site" {
 module "backend_api" {
   source = "./service/backend"
 
-  name_prefix        = local.default_name
+  name_prefix        = local.qualified_name_prefix
   service_definition = var.backend_api
   log_group_name     = local.task_log_group_name
 

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -1,6 +1,6 @@
 project_name = "Doorway" # TBD
 application_name = "Bloom Housing Instance"
-name_prefix = "doorway"
+project_id = "doorway"
 team_name = "doorway"
 aws_region = "us-west-1"
 environment = "dev"

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -1,7 +1,7 @@
 project_name = "Doorway" # TBD
 application_name = "Bloom Housing Instance"
 project_id = "doorway"
-team_name = "doorway"
+owner = "infra_team+bloom@your-org.dev"
 aws_region = "us-west-1"
 environment = "dev"
 

--- a/bloom-instance/tfvars.template
+++ b/bloom-instance/tfvars.template
@@ -3,7 +3,7 @@ application_name = "Bloom Housing Instance"
 name_prefix = "doorway"
 team_name = "doorway"
 aws_region = "us-west-1"
-sdlc_stage = "dev"
+environment = "dev"
 
 network = {
   vpc_cidr = "10.0.0.0/16"

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -28,13 +28,14 @@ variable "project_id" {
   }
 }
 
-variable "team_name" {
+# This var is only set on resource tags. Standard tag naming restrictions apply
+variable "owner" {
   type        = string
-  description = "The name of the team that owns this deployment"
+  description = "The owner of the resources created via these templates"
 
   validation {
-    condition     = can(regex("^[\\w\\s\\.\\-]+$", var.team_name))
-    error_message = "team_name can only contain letters, numbers, spaces, periods, underscores, and hyphens"
+    condition     = can(regex("^[\\w\\s\\.\\-\\:\\/\\=\\+@]{1,255}$", var.owner))
+    error_message = "owner can only contain letters, numbers, spaces, and these special characters: _ . : / = + - @"
   }
 }
 

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -55,8 +55,8 @@ variable "environment" {
   description = "The stage of the software development lifecycle this deployement represents"
 
   validation {
-    condition     = contains(["dev", "test", "qa", "staging", "prod"], var.environment)
-    error_message = "Valid values for var: environment are (dev, test, qa, staging, prod)."
+    condition     = can(regex("^[[:alpha:]][[:alnum:]]{0,10}$", var.environment))
+    error_message = "environment can only contain letters and numbers, must start with a letter, and must be 10 or fewer characters"
   }
 }
 

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -48,14 +48,14 @@ variable "aws_region" {
   }
 }
 
-variable "sdlc_stage" {
+variable "environment" {
   type        = string
   default     = "dev"
   description = "The stage of the software development lifecycle this deployement represents"
 
   validation {
-    condition     = contains(["dev", "test", "qa", "staging", "prod"], var.sdlc_stage)
-    error_message = "Valid values for var: sdlc_stage are (dev, test, qa, staging, prod)."
+    condition     = contains(["dev", "test", "qa", "staging", "prod"], var.environment)
+    error_message = "Valid values for var: environment are (dev, test, qa, staging, prod)."
   }
 }
 

--- a/bloom-instance/vars.tf
+++ b/bloom-instance/vars.tf
@@ -1,6 +1,6 @@
 variable "project_name" {
   type        = string
-  description = "Name of the project"
+  description = "A human-readable name for this project. Can be changed if needed"
 
   validation {
     condition     = can(regex("^[\\w\\s\\.\\-]+$", var.project_name))
@@ -18,13 +18,13 @@ variable "application_name" {
   }
 }
 
-variable "name_prefix" {
+variable "project_id" {
   type        = string
-  description = "A prefix to be used when creating resources to provide a distinct, yet recognizable name"
+  description = "A unique, immutable identifier for this project"
 
   validation {
-    condition     = can(regex("^[[:alnum:]\\-]+$", var.name_prefix))
-    error_message = "name_prefix can only contain letters, numbers, and hyphens"
+    condition     = can(regex("^[[:alnum:]\\-]+$", var.project_id))
+    error_message = "project_id can only contain letters, numbers, and hyphens"
   }
 }
 


### PR DESCRIPTION
This PR is primarily intended to create a new tag named `ProjectID` that permissions can be tied to, since using the current `Project` tag, which can be easily changed, has proven problematic.  As we've built more and more templates in different terraform projects, it became apparent that some of the var names used initially did not represent the intended use very well.  Since I picked out most of the names, that's on me.  In addition to renaming the `name_prefix var to `project_id`, this PR incorporates the following additional changes:

- Change `sdlc_stage` to `environment`
- Update environment validation to be less prescriptive
- Change `team_name` to `owner`
- Change `Team` tag to `Owner`
- Update owner validation to permit email addresses
- Update top-level resources to use `local.qualified_name_prefix` instead of `local.default_name`

Each change was implemented independently and tested to ensure no resources would be changed.  Only the tag changes result in updates, which are non-destructive.
