### PR TITLE
feat: add ecs autoscaling

### DIFF
--- a/bloom-instance/ecs/service/ecs.tf
+++ b/bloom-instance/ecs/service/ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "service" {
   cluster         = aws_ecs_cluster.service.id
   task_definition = local.task_id
 
-  desired_count = 1
+  desired_count = local.desired_count
   launch_type   = "FARGATE"
 
   load_balancer {

--- a/bloom-instance/ecs/service/inputs.tf
+++ b/bloom-instance/ecs/service/inputs.tf
@@ -67,6 +67,31 @@ variable "service" {
       unhealthy_threshold = optional(number, 3)
     })
 
+    scaling = optional(object({
+      enabled = optional(bool, true)
+      # The minimum number of instances to run
+      min = optional(number, 1)
+
+      # The maximum number of instance to run
+      max = number
+
+      # The number of instances to start with
+      # If less than min, min is used instead, which is why we default to 0
+      desired = optional(number, 0)
+
+      metrics = map(object({
+        name   = string
+        target = number
+      }))
+
+      }), {
+      enabled = false
+      min     = 1
+      desired = 1
+      max     = 1
+      metrics = {}
+    })
+
     # Which port to send requests to
     port = optional(number, 80)
 

--- a/bloom-instance/ecs/service/locals.tf
+++ b/bloom-instance/ecs/service/locals.tf
@@ -64,4 +64,11 @@ locals {
   security_group_ids = toset([for alb in local.filtered_albs : alb.security_group.id])
 
   subnet_ids = [for subnet in var.subnet_map[var.service.subnet_group] : subnet.id]
+
+  # Autoscaling
+  scaling     = var.service.scaling
+  use_scaling = local.scaling.enabled
+  # If the desired count is less than the min, make min the desired count
+  desired_count       = local.scaling.desired < local.scaling.min ? local.scaling.min : local.scaling.desired
+  autoscaling_metrics = (local.use_scaling ? local.scaling.metrics : {})
 }

--- a/bloom-instance/ecs/service/scaling.tf
+++ b/bloom-instance/ecs/service/scaling.tf
@@ -1,17 +1,28 @@
 
-/*
 resource "aws_appautoscaling_target" "service" {
+  count       = local.use_scaling ? 1 : 0
   resource_id = "service/${aws_ecs_cluster.service.name}/${aws_ecs_service.service.name}"
 
-  min_capacity = var.min_count
-  max_capacity = var.max_count
+  min_capacity = local.scaling.min
+  max_capacity = local.scaling.max
 
   service_namespace  = "ecs"
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
-/*
-resource "aws"appautoscaling_policy" "ecs_policy" {
+resource "aws_appautoscaling_policy" "ecs_policy" {
+  for_each           = local.autoscaling_metrics
+  name               = "${local.default_name}-scaling-policy-${each.key}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.service[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.service[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.service[0].service_namespace
 
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = each.value.name
+    }
+    target_value = each.value.target
+  }
+  depends_on = [aws_appautoscaling_target.service]
 }
-*/


### PR DESCRIPTION
This PR adds an autoscaling configuration option to the services running on ECS.  Adding this to the backend service:

```
scaling = {
  min : 1
  max : 5

  metrics = {
    cpu : {
      name : "ECSServiceAverageCPUUtilization"
      target : 80
    }
  }
}
```

Generates this output:

```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.backend_api.module.service.module.service.aws_appautoscaling_policy.ecs_policy["cpu"] will be created
  + resource "aws_appautoscaling_policy" "ecs_policy" {
      + alarm_arns         = (known after apply)
      + arn                = (known after apply)
      + id                 = (known after apply)
      + name               = "doorway-chriscasto-srv-backend-scaling-policy-cpu"
      + policy_type        = "TargetTrackingScaling"
      + resource_id        = "service/doorway-chriscasto-srv-backend/doorway-chriscasto-srv-backend"
      + scalable_dimension = "ecs:service:DesiredCount"
      + service_namespace  = "ecs"

      + target_tracking_scaling_policy_configuration {
          + disable_scale_in = false
          + target_value     = 80

          + predefined_metric_specification {
              + predefined_metric_type = "ECSServiceAverageCPUUtilization"
            }
        }
    }

  # module.backend_api.module.service.module.service.aws_appautoscaling_target.service[0] will be created
  + resource "aws_appautoscaling_target" "service" {
      + id                 = (known after apply)
      + max_capacity       = 5
      + min_capacity       = 1
      + resource_id        = "service/doorway-chriscasto-srv-backend/doorway-chriscasto-srv-backend"
      + role_arn           = (known after apply)
      + scalable_dimension = "ecs:service:DesiredCount"
      + service_namespace  = "ecs"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
```

