### PR TITLE
feat: add network outputs

### DIFF
--- a/bloom-instance/outputs.tf
+++ b/bloom-instance/outputs.tf
@@ -10,3 +10,14 @@ output "urls" {
     backend  = module.backend_api.url_list
   }
 }
+
+output "network" {
+  value = {
+    vpc_id = module.network.vpc.id
+    subnets = {
+      for name, subnet_group in module.network.subnets : name => [
+        for subnet in subnet_group : subnet.id
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Providing the right information to the app pipeline requires knowing, among other things, information about the network to run some build steps in, including the VPC ID and available subnets.  This PR adds an output to the bloom-instance project that provides these values directly for easier access.

![image](https://github.com/metrotranscom/doorway-infra/assets/23032560/3edd1e51-58ac-4ca0-a556-2477915e4c56)
