### PR TITLE
fix: add infra pipeline logging

### DIFF
--- a/infra-pipeline/pipeline/codebuild/main.tf
+++ b/infra-pipeline/pipeline/codebuild/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "aws_codebuild_project" "project" {
-  name          = "${var.name_prefix}-build-${var.name}"
+  name          = local.qualified_name
   description   = "Deployment for ${var.name_prefix} into environment ${var.name}"
   build_timeout = 60
   service_role  = aws_iam_role.codebuild.arn


### PR DESCRIPTION
The previous PR introducing the infra pipeline somehow overlooked an important component: writing to CloudWatch Logs.  Ultimately this will be covered by the pipeline module once merged and migrated, but this PR adds it in directly in the interim.  