### PR TITLE
fix: change notifications to use qualified name

### DIFF
--- a/modules/pipeline/main.tf
+++ b/modules/pipeline/main.tf
@@ -66,7 +66,7 @@ module "notification_topic" {
 
   for_each = var.notification_topics
 
-  name_prefix = local.name_prefix
+  name_prefix = local.qualified_name
   name        = each.key
   emails      = each.value.emails
 }
@@ -76,7 +76,7 @@ module "notification_rules" {
 
   for_each = { for idx, rule in var.notification_rules : idx => rule }
 
-  name_prefix = local.name_prefix
+  name_prefix = local.qualified_name
   name        = "${each.value.topic}${each.key}"
 
   topic_arn    = module.notification_topic[each.value.topic].topic_arn


### PR DESCRIPTION
The naming patterns for notification topics in the app pipeline can create collisions with other pipelines (the infra pipeline in particular) due to the insufficient namespace used.  This PR updates the pipeline module to use the fully qualified pipeline name as the prefix instead.