### PR TITLE
feat: add retag perms to ecr repos

### DIFF
--- a/app-codepipeline/ecr_repo/main.tf
+++ b/app-codepipeline/ecr_repo/main.tf
@@ -78,3 +78,35 @@ resource "aws_iam_policy" "push" {
     ],
   })
 }
+
+resource "aws_iam_policy" "retag" {
+  name = "${local.qualified_name}-retag"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # We need the ability to authenticate to ECR regardless of other permissions
+        Sid    = "AllowGetAuthorization"
+        Effect = "Allow"
+
+        Action = [
+          "ecr:GetAuthorizationToken",
+        ],
+
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowPushToRepo"
+        Effect = "Allow"
+
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:PutImage"
+        ],
+
+        Resource = local.arn
+      },
+    ],
+  })
+}

--- a/app-codepipeline/ecr_repo/outputs.tf
+++ b/app-codepipeline/ecr_repo/outputs.tf
@@ -1,8 +1,9 @@
 
 output "policy_arns" {
   value = {
-    push = aws_iam_policy.push.arn
-    pull = aws_iam_policy.pull.arn
+    push  = aws_iam_policy.push.arn
+    pull  = aws_iam_policy.pull.arn
+    retag = aws_iam_policy.retag.arn
   }
 }
 

--- a/app-codepipeline/main.tf
+++ b/app-codepipeline/main.tf
@@ -95,7 +95,7 @@ locals {
                       for repo_id, perms in try(action.ecr_repo_access, {}) : concat([
                         for perm in perms : [
                           module.ecr_repos[repo_id].policy_arns[perm]
-                        ] if contains(["push", "pull"], perm)
+                        ] if contains(["push", "pull", "retag"], perm)
                       ]...) if try(action.ecr_repo_access, null) != null
                     ]...), []))
                   )


### PR DESCRIPTION
The app pipeline auto generates permissions for each of the repos in the configuration: one set for pulling images and another for pushing.  This makes it much easier to restrict certain pipeline actions to just being able to perform specific actions one specific repos.  This extends those permissions to also include a "retag" capability, that permits actions to add new tags to existing images.