### PR TITLE
feat: use route 53 aliases

### DIFF
--- a/bloom-instance/alb/outputs.tf
+++ b/bloom-instance/alb/outputs.tf
@@ -27,3 +27,7 @@ output "log_prefix" {
 output "dns_name" {
   value = aws_lb.alb.dns_name
 }
+
+output "zone_id" {
+  value = aws_lb.alb.zone_id
+}

--- a/bloom-instance/dns/alias/inputs.tf
+++ b/bloom-instance/dns/alias/inputs.tf
@@ -1,0 +1,22 @@
+
+variable "zones" {
+  type        = map(string)
+  description = "A map of zone names to IDs"
+}
+
+variable "record" {
+  type = object({
+    # The DNS name for the record, ie google.com
+    name = string
+
+    # The type of record to create (CNAME, A, TXT, etc)
+    type = string
+
+    target = object({
+      dns_name = string
+      zone_id  = string
+    })
+  })
+
+  description = "Attributes for the Alias to create"
+}

--- a/bloom-instance/dns/alias/main.tf
+++ b/bloom-instance/dns/alias/main.tf
@@ -15,12 +15,17 @@ locals {
   zone_id = local.matches[0]
 }
 
-resource "aws_route53_record" "record" {
+resource "aws_route53_record" "alias" {
   count = local.zone_id != null ? 1 : 0
 
   zone_id = local.zone_id
   name    = var.record.name
   type    = var.record.type
-  ttl     = var.record.ttl
-  records = var.record.values
+
+  alias {
+    name    = var.record.target.dns_name
+    zone_id = var.record.target.zone_id
+
+    evaluate_target_health = false
+  }
 }

--- a/bloom-instance/dns/alias/outputs.tf
+++ b/bloom-instance/dns/alias/outputs.tf
@@ -1,0 +1,4 @@
+
+output "fqdn" {
+  value = local.zone_id != null ? aws_route53_record.alias[0].fqdn : null
+}

--- a/bloom-instance/service/dns.tf
+++ b/bloom-instance/service/dns.tf
@@ -4,17 +4,22 @@ locals {
     for listener_name, listener in alb.listeners : {
       for domain in listener.domains : "${local.name}-${alb_name}-${listener_name}-${domain}" => {
         name   = domain
-        type   = "CNAME"
+        type   = "A"
         values = [var.alb_map[alb_name].dns_name]
-        ttl    = var.dns.default_ttl
+        #ttl    = var.dns.default_ttl
+
+        target = {
+          dns_name = var.alb_map[alb_name].dns_name
+          zone_id  = var.alb_map[alb_name].zone_id
+        }
       }
     }
     ]...)
   ]...)
 }
 
-module "alb_dns" {
-  source = "../dns/record"
+module "alb_aliases" {
+  source = "../dns/alias"
 
   for_each = local.alb_domain_map
 

--- a/bloom-instance/service/inputs.tf
+++ b/bloom-instance/service/inputs.tf
@@ -32,6 +32,7 @@ variable "alb_map" {
   type = map(object({
     arn      = string
     dns_name = string
+    zone_id  = string
     security_group = object({
       id = string
     })


### PR DESCRIPTION
Up until now, CNAME records were used to map the desired domain names to the ALBs fronting our services.  This has worked well until recently, when it became necessary to use a domain apex record for the production public site.  It's not possible to use CNAMEs on apex records, but it is possible to use Route 53 Aliases instead.  This PR adds an alias module and modifies the service module to use that instead.