### PR TITLE
fix: make plan output name unique

### DIFF
--- a/bloom-instance/alb/outputs.tf
+++ b/bloom-instance/alb/outputs.tf
@@ -27,3 +27,7 @@ output "log_prefix" {
 output "dns_name" {
   value = aws_lb.alb.dns_name
 }
+
+output "zone_id" {
+  value = aws_lb.alb.zone_id
+}

--- a/bloom-instance/dns/alias/inputs.tf
+++ b/bloom-instance/dns/alias/inputs.tf
@@ -1,0 +1,22 @@
+
+variable "zones" {
+  type        = map(string)
+  description = "A map of zone names to IDs"
+}
+
+variable "record" {
+  type = object({
+    # The DNS name for the record, ie google.com
+    name = string
+
+    # The type of record to create (CNAME, A, TXT, etc)
+    type = string
+
+    target = object({
+      dns_name = string
+      zone_id  = string
+    })
+  })
+
+  description = "Attributes for the Alias to create"
+}

--- a/bloom-instance/dns/alias/main.tf
+++ b/bloom-instance/dns/alias/main.tf
@@ -15,12 +15,17 @@ locals {
   zone_id = local.matches[0]
 }
 
-resource "aws_route53_record" "record" {
+resource "aws_route53_record" "alias" {
   count = local.zone_id != null ? 1 : 0
 
   zone_id = local.zone_id
   name    = var.record.name
   type    = var.record.type
-  ttl     = var.record.ttl
-  records = var.record.values
+
+  alias {
+    name    = var.record.target.dns_name
+    zone_id = var.record.target.zone_id
+
+    evaluate_target_health = false
+  }
 }

--- a/bloom-instance/dns/alias/outputs.tf
+++ b/bloom-instance/dns/alias/outputs.tf
@@ -1,0 +1,4 @@
+
+output "fqdn" {
+  value = local.zone_id != null ? aws_route53_record.alias[0].fqdn : null
+}

--- a/bloom-instance/service/dns.tf
+++ b/bloom-instance/service/dns.tf
@@ -4,17 +4,22 @@ locals {
     for listener_name, listener in alb.listeners : {
       for domain in listener.domains : "${local.name}-${alb_name}-${listener_name}-${domain}" => {
         name   = domain
-        type   = "CNAME"
+        type   = "A"
         values = [var.alb_map[alb_name].dns_name]
-        ttl    = var.dns.default_ttl
+        #ttl    = var.dns.default_ttl
+
+        target = {
+          dns_name = var.alb_map[alb_name].dns_name
+          zone_id  = var.alb_map[alb_name].zone_id
+        }
       }
     }
     ]...)
   ]...)
 }
 
-module "alb_dns" {
-  source = "../dns/record"
+module "alb_aliases" {
+  source = "../dns/alias"
 
   for_each = local.alb_domain_map
 

--- a/bloom-instance/service/inputs.tf
+++ b/bloom-instance/service/inputs.tf
@@ -32,6 +32,7 @@ variable "alb_map" {
   type = map(object({
     arn      = string
     dns_name = string
+    zone_id  = string
     security_group = object({
       id = string
     })

--- a/infra-pipeline/pipeline/main.tf
+++ b/infra-pipeline/pipeline/main.tf
@@ -31,7 +31,7 @@ locals {
     : "${local.cloudbuild_src_dir_var}_${var.tf_root.source}"
   )
 
-  plan_file_artifact_name = "plan"
+  plan_file_artifact_prefix = "plan"
 }
 
 module "plan" {
@@ -105,7 +105,7 @@ module "apply" {
       TF_ROOT_PATH = var.tf_root.path
 
       # We use this to indicate which var holds the path to the artifact for the plan file
-      TF_PLAN_SOURCE_VAR_NAME = "${local.cloudbuild_src_dir_var}_${local.plan_file_artifact_name}"
+      TF_PLAN_SOURCE_VAR_NAME = "${local.cloudbuild_src_dir_var}_${local.plan_file_artifact_prefix}_${each.key}"
 
       # This holds the relative path to the plan file
       TF_PLAN_PATH = "plan.out"
@@ -184,7 +184,7 @@ resource "aws_codepipeline" "pipeline" {
         provider         = "CodeBuild"
         version          = "1"
         input_artifacts  = local.source_artifacts
-        output_artifacts = [local.plan_file_artifact_name]
+        output_artifacts = ["${local.plan_file_artifact_prefix}_${stage.value.name}"]
         run_order        = 1
 
         configuration = {
@@ -222,7 +222,7 @@ resource "aws_codepipeline" "pipeline" {
         provider = "CodeBuild"
         version  = "1"
         # Add plan file from "Plan" action to input artifacts
-        input_artifacts = concat(local.source_artifacts, [local.plan_file_artifact_name])
+        input_artifacts = concat(local.source_artifacts, ["${local.plan_file_artifact_prefix}_${stage.value.name}"])
         run_order       = 4
 
         configuration = {


### PR DESCRIPTION
The output artifact for the plan file generated in the first step of each stage in the infra pipeline had a single static name.  This worked fine when it was just dev, but with staging and prod added it threw an error.  This resolves that by namespacing the output to the environment.