### PR TITLE
fix: always return alb log prefix

### DIFF
--- a/bloom-instance/alb/outputs.tf
+++ b/bloom-instance/alb/outputs.tf
@@ -21,7 +21,7 @@ output "listeners" {
 
 # Used for generating log bucket policy
 output "log_prefix" {
-  value = var.enable_logging ? local.log_prefix : ""
+  value = local.log_prefix
 }
 
 output "dns_name" {


### PR DESCRIPTION
The ALB module generates and uses a log bucket prefix which is conditionally output if logging is enabled and used to generate the policy for the log bucket.  It isn't possible to modify the policy directly within the module (there can only be one version of it), so the policy always has to know all of the ALB prefixes when it is created.  This creates an odd circular dependency where the policy has to know about all of the ALBs, but the policy also has to be in place in order for the ALBs to be created with logging enabled.  There's a larger fix to eliminate this circular dependency by generating prefixes externally and passing them into both, but it's more complexity than is warranted at this stage.  By always outputting the prefix we can ensure that the correct policy is created, and as long as ALBs are first created with logging disabled, they can be easily updated later to turn logging back on without issue.