### PR TITLE
fix: update backend s3 policy

### DIFF
--- a/bloom-instance/service/backend/locals.tf
+++ b/bloom-instance/service/backend/locals.tf
@@ -20,7 +20,7 @@ locals {
 
   # The value to use in IAM policies restricting access to upload objects
   s3_access_policy_object_resource = [
-    "${local.public_bucket_arn}/${local.bucket_prefix}/*",
+    "${local.public_bucket_arn}/*",
     // Another can be added here in the future if files need to be uploaded to non-public bucket(s)
   ]
 

--- a/bloom-instance/service/backend/locals.tf
+++ b/bloom-instance/service/backend/locals.tf
@@ -20,8 +20,12 @@ locals {
 
   # The value to use in IAM policies restricting access to upload objects
   s3_access_policy_object_resource = [
+    # Use this for now
     "${local.public_bucket_arn}/*",
-    // Another can be added here in the future if files need to be uploaded to non-public bucket(s)
+    # Use this when/if prefix is implemented
+    #"${local.public_bucket_arn}/${local.bucket_prefix}/*",
+
+    # Others can be added here in the future if files need to be uploaded to non-public bucket(s)
   ]
 
   # Add service-specific env vars


### PR DESCRIPTION
The IAM policy used by the backend for pushing assets to S3 included a prefix component that was never used, causing the S3 ARN to be invalid.  This removes the prefix from the ARN