### PR TITLE
fix: change log bucket prefix

### DIFF
--- a/bloom-instance/logging.tf
+++ b/bloom-instance/logging.tf
@@ -1,6 +1,8 @@
 resource "aws_s3_bucket" "logging_bucket" {
-  bucket_prefix = "${local.project_id}-logging"
-  #bucket_prefix = "${local.qualified_name_prefix}-logging"
+  bucket_prefix = "${local.qualified_name_prefix}-logging"
+  # Uncomment to have the bucket automatically delete all objects in it when destroyed
+  # By default, buckets with objects in them cannot be deleted
+  #force_destroy = true
 }
 
 resource "aws_s3_bucket_policy" "log_bucket_policy" {

--- a/bloom-instance/logging.tf
+++ b/bloom-instance/logging.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "logging_bucket" {
-  bucket_prefix = "${local.qualified_name_prefix}-logging"
+  bucket_prefix = "${local.project_id}-logging"
+  #bucket_prefix = "${local.qualified_name_prefix}-logging"
 }
 
 resource "aws_s3_bucket_policy" "log_bucket_policy" {

--- a/bloom-instance/logging.tf
+++ b/bloom-instance/logging.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "logging_bucket" {
-  bucket_prefix = "${local.project_id}-logging"
+  bucket_prefix = "${local.qualified_name_prefix}-logging"
 }
 
 resource "aws_s3_bucket_policy" "log_bucket_policy" {


### PR DESCRIPTION
The bucket used for storing log files has a prefix that isn't fully qualified, resulting in IAM issues and making it difficult to determine which environment it applies to.  This PR updates the prefix with the environment name to eliminate these issues